### PR TITLE
Feat/auth

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,91 +1,111 @@
-// Prisma Schema for Corea Hoy (MVP v1.0)
-
 generator client {
   provider = "prisma-client-js"
 }
 
 datasource db {
-  provider = "postgresql" // Supabase 사용 시 postgresql 설정
+  provider = "postgresql"
   url      = env("DATABASE_URL")
 }
 
-// 유저 정보 (구글 인증 기반)
-model User {
-  id            String    @id @default(uuid())
-  email         String    @unique
-  name          String?
-  image         String?
-  role          Role      @default(USER) // USER, ADMIN 구분
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
-
-  // 관계 설정
-  articles      Article[] // 관리자일 경우 작성한 기사들
-  comments      Comment[]
-  likes         Like[]
+model article_sources {
+  id         Int      @id @default(autoincrement())
+  article_id String   @db.Uuid
+  title      String?
+  url        String
+  articles   articles @relation(fields: [article_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
 }
 
-// 뉴스 기사 (핵심 데이터)
-model Article {
-  id                String        @id @default(uuid())
-  title             String        // 스페인어 번역 제목
-  content           String        // 스페인어 번역 본문 (요약 포함)
-  originalUrl       String        // 네이버 뉴스 등 원문 링크
-  imageUrl          String?       // 기사 썸네일
-  status            ArticleStatus @default(DRAFT) // DRAFT, PUBLISHED
-  viewCount         Int           @default(0)
-  
-  category          Category      @relation(fields: [categoryId], references: [id])
-  categoryId        String
-
-  author            User?         @relation(fields: [authorId], references: [id])
-  authorId          String?
-
-  createdAt         DateTime      @default(now())
-  updatedAt         DateTime      @updatedAt
-
-  // 관계 설정
-  comments          Comment[]
-  likes             Like[]
+model articles {
+  id               String            @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  title_ko         String
+  body_ko          String
+  cultural_note_ko String?
+  title_es         String?
+  body_es          String?
+  cultural_note_es String?
+  thumbnail_url    String?
+  status           ArticleStatus     @default(DRAFT)
+  draft_step       DraftStep         @default(select)
+  lang_status_ko   LangStatus        @default(pending)
+  lang_status_es   LangStatus        @default(pending)
+  view_count       Int               @default(0)
+  category_id      Int
+  published_at     DateTime?         @db.Timestamptz(6)
+  created_at       DateTime          @default(now()) @db.Timestamptz(6)
+  updated_at       DateTime          @default(now()) @db.Timestamptz(6)
+  article_sources  article_sources[]
+  categories       categories        @relation(fields: [category_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  comments         comments[]
+  likes            likes[]
+  scraps           scraps[]
 }
 
-// 카테고리 (K-POP, 드라마 등)
-model Category {
-  id        String    @id @default(uuid())
-  name      String    @unique // 예: "K-POP", "Drama", "Life"
-  articles  Article[]
+model categories {
+  id       Int        @id @default(autoincrement())
+  name     String
+  slug     String     @unique
+  articles articles[]
 }
 
-// 댓글
-model Comment {
-  id        String   @id @default(uuid())
-  content   String
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  userId    String
-
-  article   Article  @relation(fields: [articleId], references: [id], onDelete: Cascade)
-  articleId String
+model comments {
+  id         String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  body       String
+  article_id String    @db.Uuid
+  user_id    String    @db.Uuid
+  created_at DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at DateTime  @default(now()) @db.Timestamptz(6)
+  deleted_at DateTime? @db.Timestamptz(6)
+  articles   articles  @relation(fields: [article_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  users      users     @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
 }
 
-// 좋아요 (마이페이지 저장 기능 겸용)
-model Like {
-  id        String   @id @default(uuid())
-  createdAt DateTime @default(now())
-
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  userId    String
-
-  article   Article  @relation(fields: [articleId], references: [id], onDelete: Cascade)
-  articleId String
-
-  // 한 유저가 한 기사에 좋아요를 한 번만 누를 수 있도록 설정
-  @@unique([userId, articleId])
+model feedbacks {
+  id             String           @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  category       FeedbackCategory
+  other_category String?
+  body           String
+  email          String?
+  submitted_by   String
+  user_id        String?          @db.Uuid
+  created_at     DateTime         @default(now()) @db.Timestamptz(6)
+  users          users?           @relation(fields: [user_id], references: [id], onUpdate: NoAction)
 }
 
-// Enum 타입 정의
+model likes {
+  user_id    String   @db.Uuid
+  article_id String   @db.Uuid
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+  articles   articles @relation(fields: [article_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  users      users    @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@id([user_id, article_id])
+}
+
+model scraps {
+  user_id    String   @db.Uuid
+  article_id String   @db.Uuid
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+  articles   articles @relation(fields: [article_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  users      users    @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@id([user_id, article_id])
+}
+
+model users {
+  id           String      @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  google_id    String      @unique
+  email        String      @unique
+  nickname     String?
+  avatar_emoji String?
+  avatar_color String?
+  role         UserRole    @default(USER)
+  created_at   DateTime    @default(now()) @db.Timestamptz(6)
+  comments     comments[]
+  feedbacks    feedbacks[]
+  likes        likes[]
+  scraps       scraps[]
+}
+
 enum Role {
   USER
   ADMIN
@@ -94,4 +114,31 @@ enum Role {
 enum ArticleStatus {
   DRAFT
   PUBLISHED
+  ARCHIVED
+}
+
+enum DraftStep {
+  select
+  review_ko @map("review-ko")
+  review_es @map("review-es")
+  preview
+}
+
+enum FeedbackCategory {
+  ui
+  content
+  translation
+  feature
+  bug
+  other
+}
+
+enum LangStatus {
+  pending
+  done
+}
+
+enum UserRole {
+  USER
+  ADMIN
 }

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -1,0 +1,33 @@
+import { Request, Response, NextFunction } from 'express';
+import * as authService from '../services/auth.service';
+
+/**
+ * 내 정보 조회 및 자동 회원가입 API
+ * 프론트엔드(NextAuth)가 보낸 JWT를 기반으로 DB 유저를 반환합니다.
+ */
+export const getMe = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    // authMiddleware를 통과했다면 req.user에 토큰 해독 정보가 들어있습니다.
+    const decodedUser = req.user;
+
+    if (!decodedUser || !decodedUser.email) {
+      res.status(400).json({ message: '토큰에서 이메일 정보를 찾을 수 없습니다.' });
+      return;
+    }
+
+    // Service 호출하여 DB 확인 및 생성
+    const user = await authService.findOrCreateUser({
+      email: decodedUser.email,
+      sub: decodedUser.sub,
+      name: decodedUser.name || decodedUser.email.split('@')[0], // 이름이 없으면 이메일 앞자리 사용
+      image: decodedUser.picture || decodedUser.image, // 구글은 picture, NextAuth는 image로 줄 수 있음
+    });
+
+    res.status(200).json({
+      message: '유저 정보 조회 성공',
+      user,
+    });
+  } catch (error) {
+    next(error); // 에러 핸들러로 전달
+  }
+};

--- a/src/lib/swagger.ts
+++ b/src/lib/swagger.ts
@@ -10,7 +10,7 @@ const options: swaggerJsdoc.Options = {
     },
     servers: [
       {
-        url: 'http://localhost:4000',
+        url: 'http://localhost:1234',
         description: '개발 서버',
       },
     ],

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -13,6 +13,7 @@ export interface JwtPayload {
 
 // Request 타입에 user 필드 추가 (TypeScript 타입 확장)
 declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Express {
     interface Request {
       user?: JwtPayload;

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -2,9 +2,13 @@ import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 
 export interface JwtPayload {
-  userId: string;
+  sub?: string;
+  userId?: string;
   email: string;
-  role: 'USER' | 'ADMIN';
+  role?: 'USER' | 'ADMIN';
+  name?: string;
+  picture?: string;
+  image?: string;
 }
 
 // Request 타입에 user 필드 추가 (TypeScript 타입 확장)
@@ -28,7 +32,9 @@ export function authMiddleware(req: Request, res: Response, next: NextFunction):
   const token = authHeader.split(' ')[1];
 
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET!) as JwtPayload;
+    // NextAuth 비밀키를 우선 사용하고, 없으면 기본 JWT_SECRET 사용
+    const secret = process.env.NEXTAUTH_SECRET || process.env.JWT_SECRET!;
+    const decoded = jwt.verify(token, secret) as JwtPayload;
     req.user = decoded;
     next();
   } catch {

--- a/src/routes/auth.route.ts
+++ b/src/routes/auth.route.ts
@@ -1,4 +1,6 @@
-import { Router, Request, Response } from 'express';
+import { Router } from 'express';
+import { getMe } from '../controllers/auth.controller';
+import { authMiddleware } from '../middlewares/auth.middleware';
 
 const router = Router();
 
@@ -6,35 +8,23 @@ const router = Router();
  * @swagger
  * tags:
  *   name: Auth
- *   description: 인증
+ *   description: 인증 및 유저 정보
  */
 
 /**
  * @swagger
- * /api/auth/google:
- *   post:
- *     summary: Google OAuth 로그인 후 유저 등록 및 JWT 발급
+ * /api/auth/me:
+ *   get:
+ *     summary: 내 정보 조회 및 최초 로그인 시 유저 자동 생성 (JIT Provisioning)
  *     tags: [Auth]
+ *     security:
+ *       - bearerAuth: []
  *     responses:
  *       200:
- *         description: JWT 발급 성공
+ *         description: 유저 정보 조회 및 DB 동기화 성공
+ *       401:
+ *         description: 인증 토큰이 없거나 유효하지 않음
  */
-router.post('/google', (req: Request, res: Response) => {
-  res.json({ message: 'google auth' });
-});
-
-/**
- * @swagger
- * /api/auth/refresh:
- *   post:
- *     summary: Access Token 만료 시 갱신
- *     tags: [Auth]
- *     responses:
- *       200:
- *         description: 토큰 갱신 성공
- */
-router.post('/refresh', (req: Request, res: Response) => {
-  res.json({ message: 'refresh token' });
-});
+router.get('/me', authMiddleware, getMe);
 
 export default router;

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,0 +1,33 @@
+import { prisma } from '../lib/prisma';
+import { users } from '@prisma/client';
+
+// 프론트엔드(토큰)로부터 받을 유저 정보의 타입 정의
+export interface UserPayload {
+  email: string;
+  sub?: string;
+  name?: string;
+  image?: string;
+}
+
+/**
+ * 주어진 이메일로 유저를 찾고, 없으면 새로 생성합니다. (Upsert 패턴)
+ */
+export const findOrCreateUser = async (payload: UserPayload): Promise<users> => {
+  const user = await prisma.users.upsert({
+    where: {
+      email: payload.email
+    },
+    update: {
+      nickname: payload.name,
+      avatar_emoji: payload.image,
+    },
+    create: {
+      email: payload.email,
+      google_id: payload.sub || payload.email, // google_id는 필수이므로 sub가 없으면 email을 대용합니다.
+      nickname: payload.name,
+      avatar_emoji: payload.image,
+    },
+  });
+
+  return user;
+};

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,5 +1,5 @@
 import { prisma } from '../lib/prisma';
-import { users } from '@prisma/client';
+import { User } from '@prisma/client';
 
 // 프론트엔드(토큰)로부터 받을 유저 정보의 타입 정의
 export interface UserPayload {
@@ -12,20 +12,20 @@ export interface UserPayload {
 /**
  * 주어진 이메일로 유저를 찾고, 없으면 새로 생성합니다. (Upsert 패턴)
  */
-export const findOrCreateUser = async (payload: UserPayload): Promise<users> => {
-  const user = await prisma.users.upsert({
+export const findOrCreateUser = async (payload: UserPayload): Promise<User> => {
+  const user = await prisma.user.upsert({
     where: {
       email: payload.email
     },
     update: {
       nickname: payload.name,
-      avatar_emoji: payload.image,
+      avatarEmoji: payload.image,
     },
     create: {
       email: payload.email,
-      google_id: payload.sub || payload.email, // google_id는 필수이므로 sub가 없으면 email을 대용합니다.
+      googleId: payload.sub || payload.email,
       nickname: payload.name,
-      avatar_emoji: payload.image,
+      avatarEmoji: payload.image,
     },
   });
 


### PR DESCRIPTION
closes #9 

---
## 작업 내용

인증 api 구현
#### **1. 인증 아키텍처 수립**
*   NextAuth(FE)가 인증을 주도하고, Express(BE)는 전달받은 JWT를 검증하는 하이브리드 구조를 채택했습니다.
*   공유된 `NEXTAUTH_SECRET`을 사용하여 토큰의 유효성을 검사합니다.

#### **2. JIT(Just-In-Time) 유저 등록 구현**
*   별도의 가입 API 호출 없이, **`GET /api/auth/me`** 호출 시 토큰 정보를 기반으로 DB에 유저가 없으면 자동으로 회원가입(Upsert)을 진행합니다.
*   기존 유저는 프로필 정보(닉네임, 이미지)가 최신화됩니다.

#### **3. FE 연동 가이드**
*   **엔드포인트**: `GET /api/auth/me`
*   **인증 방식**: Bearer Token (Authorization 헤더에 NextAuth JWT 실어서 전송)
*   **토큰 필수 데이터**: `email`, `sub`(Google ID), `name`(nickname), `picture/image`

#### **4. API 문서화**
*   Swagger를 통해 상세 명세를 확인하고 직접 테스트해 볼 수 있습니다. (`/api-docs`)

---

## 체크리스트
- [x] 로컬 동작 확인
- [x] ESLint 오류 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated endpoint to fetch and auto-create/sync the current user's profile.

* **Infrastructure**
  * Database schema strengthened: UUID defaults/typing and higher-precision timestamps standardized across models; relation behaviors clarified.
  * Authentication expanded: token payload accepts more identity fields and uses a clarified secret-selection flow.

* **Documentation**
  * Development server URL updated in API docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->