### PR TITLE
fix: 피드백글자수제한

### DIFF
--- a/src/controllers/feedback.controller.ts
+++ b/src/controllers/feedback.controller.ts
@@ -14,6 +14,12 @@ export const submitFeedback = async (req: Request, res: Response, next: NextFunc
       return;
     }
 
+    // 글자수 제한
+    if (body.length > 1000) {
+      res.status(400).json({ success: false, message: '내용은 1000자 이하로 입력해주세요.' });
+      return;
+    }
+
     // category enum 검증
     if (!VALID_CATEGORIES.includes(category as FeedbackCategory)) {
       res.status(400).json({

--- a/src/routes/articles.route.ts
+++ b/src/routes/articles.route.ts
@@ -7,14 +7,14 @@ const router = Router();
  * @swagger
  * tags:
  *   name: Articles
- *   description: 뉴스 컨텐츠 🥒
+ *   description: 뉴스 컨텐츠
  */
 
 /**
  * @swagger
  * /api/articles:
  *   get:
- *     summary: 뉴스 피드 조회 (카테고리, 검색, 정렬)
+ *     summary: 뉴스 피드 조회 (카테고리, 검색, 정렬)🥒
  *     tags: [Articles]
  *     parameters:
  *       - in: query
@@ -51,7 +51,7 @@ router.get('/', getArticlesController);
  * @swagger
  * /api/articles/{id}:
  *   get:
- *     summary: 뉴스 상세 조회 (조회수 +1)
+ *     summary: 뉴스 상세 조회 (조회수 +1)🥒
  *     tags: [Articles]
  *     parameters:
  *       - in: path

--- a/src/routes/auth.route.ts
+++ b/src/routes/auth.route.ts
@@ -15,7 +15,7 @@ const router = Router();
  * @swagger
  * /api/auth/me:
  *   get:
- *     summary: 내 정보 조회 및 최초 로그인 시 유저 자동 생성 (JIT Provisioning)
+ *     summary: 내 정보 조회 및 최초 로그인 시 유저 자동 생성 (JIT Provisioning)🥒
  *     tags: [Auth]
  *     security:
  *       - bearerAuth: []

--- a/src/routes/categories.route.ts
+++ b/src/routes/categories.route.ts
@@ -7,14 +7,14 @@ const router = Router();
  * @swagger
  * tags:
  *   name: Categories
- *   description: 카테고리 🥒
+ *   description: 카테고리
  */
 
 /**
  * @swagger
  * /api/categories:
  *   get:
- *     summary: 카테고리 목록 조회
+ *     summary: 카테고리 목록 조회 🥒
  *     tags: [Categories]
  *     responses:
  *       200:

--- a/src/routes/feedback.route.ts
+++ b/src/routes/feedback.route.ts
@@ -7,14 +7,14 @@ const router = Router();
  * @swagger
  * tags:
  *   name: Feedback
- *   description: 피드백 🥒
+ *   description: 피드백
  */
 
 /**
  * @swagger
  * /api/feedback:
  *   post:
- *     summary: 피드백 제출 (비로그인 가능)
+ *     summary: 피드백 제출 (비로그인 가능)🥒
  *     tags: [Feedback]
  *     requestBody:
  *       required: true
@@ -33,7 +33,8 @@ const router = Router();
  *                 description: category가 other일 때 필수
  *               body:
  *                 type: string
- *                 description: 상세 내용 (필수)
+ *                 maxLength: 1000
+ *                 description: 상세 내용 (필수, 최대 1000자)
  *               email:
  *                 type: string
  *                 description: 답변 받을 이메일 (선택)


### PR DESCRIPTION
closes #12 

## 작업 내용
피드백 폼 내용 글자수를 1000자로 제한합니다.

## 체크리스트
- [x] 로컬 동작 확인
- [x] ESLint 오류 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Feedback submissions now validate body length, rejecting messages exceeding 1000 characters with a clear error response.

* **Documentation**
  * Updated API documentation for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->