### PR TITLE
feat: 어드민 파이프라인 구현 및 뉴스 수집 고도화

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,1 @@
+language: "ko-KR"

--- a/src/controllers/admin.controller.ts
+++ b/src/controllers/admin.controller.ts
@@ -116,22 +116,18 @@ export const createDraftArticle = async (req: Request, res: Response, next: Next
     }
 
     if (langStatusKo && !validLangStatuses.includes(langStatusKo as LangStatus)) {
-      res
-        .status(400)
-        .json({
-          success: false,
-          message: `langStatusKo는 ${validLangStatuses.join(', ')} 중 하나여야 합니다.`,
-        });
+      res.status(400).json({
+        success: false,
+        message: `langStatusKo는 ${validLangStatuses.join(', ')} 중 하나여야 합니다.`,
+      });
       return;
     }
 
     if (langStatusEs && !validLangStatuses.includes(langStatusEs as LangStatus)) {
-      res
-        .status(400)
-        .json({
-          success: false,
-          message: `langStatusEs는 ${validLangStatuses.join(', ')} 중 하나여야 합니다.`,
-        });
+      res.status(400).json({
+        success: false,
+        message: `langStatusEs는 ${validLangStatuses.join(', ')} 중 하나여야 합니다.`,
+      });
       return;
     }
 
@@ -151,6 +147,11 @@ export const createDraftArticle = async (req: Request, res: Response, next: Next
       langStatusEs: langStatusEs as LangStatus | undefined,
     });
 
+    if (!article) {
+      res.status(400).json({ success: false, message: '이미 저장된 기사입니다. (sourceUrl 중복)' });
+      return;
+    }
+
     res.status(201).json({ success: true, data: article });
   } catch (err) {
     next(err);
@@ -164,21 +165,17 @@ export const updateArticle = async (req: Request, res: Response, next: NextFunct
       body.draftStep = draftStepMap[body.draftStep];
     }
     if (body.langStatusKo && !validLangStatuses.includes(body.langStatusKo as LangStatus)) {
-      res
-        .status(400)
-        .json({
-          success: false,
-          message: `langStatusKo는 ${validLangStatuses.join(', ')} 중 하나여야 합니다.`,
-        });
+      res.status(400).json({
+        success: false,
+        message: `langStatusKo는 ${validLangStatuses.join(', ')} 중 하나여야 합니다.`,
+      });
       return;
     }
     if (body.langStatusEs && !validLangStatuses.includes(body.langStatusEs as LangStatus)) {
-      res
-        .status(400)
-        .json({
-          success: false,
-          message: `langStatusEs는 ${validLangStatuses.join(', ')} 중 하나여야 합니다.`,
-        });
+      res.status(400).json({
+        success: false,
+        message: `langStatusEs는 ${validLangStatuses.join(', ')} 중 하나여야 합니다.`,
+      });
       return;
     }
     const article = await adminService.updateArticle(req.params.id as string, body);

--- a/src/controllers/admin.controller.ts
+++ b/src/controllers/admin.controller.ts
@@ -1,0 +1,187 @@
+import { Request, Response, NextFunction } from 'express';
+import { ArticleStatus, DraftStep, LangStatus } from '@prisma/client';
+import * as adminService from '../services/admin.service';
+
+const draftStepMap: Record<string, DraftStep> = {
+  select: DraftStep.select,
+  'review-ko': DraftStep.review_ko,
+  'review-es': DraftStep.review_es,
+  preview: DraftStep.preview,
+};
+
+// ============================================
+// 파이프라인 - 뉴스 수집
+// ============================================
+
+export const searchNews = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const articles = await adminService.searchNews();
+    res.json({ success: true, data: articles });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// ============================================
+// 파이프라인 - AI 생성 / 번역
+// ============================================
+
+export const generateContent = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { mode, title, content, titleKo, bodyKo } = req.body ?? {};
+
+    if (!mode || !['generate', 'translate'].includes(mode)) {
+      res
+        .status(400)
+        .json({ success: false, message: 'mode는 generate 또는 translate여야 합니다.' });
+      return;
+    }
+
+    if (mode === 'generate' && (!title || !content)) {
+      res
+        .status(400)
+        .json({ success: false, message: 'generate 모드는 title과 content가 필요합니다.' });
+      return;
+    }
+
+    if (mode === 'translate' && (!titleKo || !bodyKo)) {
+      res
+        .status(400)
+        .json({ success: false, message: 'translate 모드는 titleKo와 bodyKo가 필요합니다.' });
+      return;
+    }
+
+    const result = await adminService.generateContent(mode, { title, content, titleKo, bodyKo });
+    res.json({ success: true, data: result });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// ============================================
+// 기사 CRUD
+// ============================================
+
+export const getAdminArticles = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { status } = req.query;
+    const page = Math.max(1, parseInt(req.query.page as string) || 1);
+    const limit = Math.min(50, Math.max(1, parseInt(req.query.limit as string) || 20));
+
+    const validStatuses = Object.values(ArticleStatus);
+    if (status && !validStatuses.includes(status as ArticleStatus)) {
+      res
+        .status(400)
+        .json({
+          success: false,
+          message: `status는 ${validStatuses.join(', ')} 중 하나여야 합니다.`,
+        });
+      return;
+    }
+
+    const result = await adminService.getAdminArticles(
+      status as ArticleStatus | undefined,
+      page,
+      limit,
+    );
+    res.json({ success: true, data: result });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const createDraftArticle = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const {
+      titleKo,
+      bodyKo,
+      culturalNoteKo,
+      titleEs,
+      bodyEs,
+      culturalNoteEs,
+      thumbnailUrl,
+      categoryId,
+      sourceUrl,
+      sourceTitle,
+      draftStep,
+      langStatusKo,
+      langStatusEs,
+    } = req.body ?? {};
+
+    if (!titleKo || !bodyKo || !categoryId || !sourceUrl) {
+      res
+        .status(400)
+        .json({ success: false, message: 'titleKo, bodyKo, categoryId, sourceUrl은 필수입니다.' });
+      return;
+    }
+
+    const article = await adminService.createDraftArticle({
+      titleKo,
+      bodyKo,
+      culturalNoteKo,
+      titleEs,
+      bodyEs,
+      culturalNoteEs,
+      thumbnailUrl,
+      categoryId: Number(categoryId),
+      sourceUrl,
+      sourceTitle,
+      draftStep: draftStep ? draftStepMap[draftStep] : undefined,
+      langStatusKo: langStatusKo as LangStatus | undefined,
+      langStatusEs: langStatusEs as LangStatus | undefined,
+    });
+
+    res.status(201).json({ success: true, data: article });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const updateArticle = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const body = { ...(req.body ?? {}) };
+    if (body.draftStep && draftStepMap[body.draftStep]) {
+      body.draftStep = draftStepMap[body.draftStep];
+    }
+    const article = await adminService.updateArticle(req.params.id as string, body);
+
+    if (!article) {
+      res.status(404).json({ success: false, message: '기사를 찾을 수 없습니다.' });
+      return;
+    }
+
+    res.json({ success: true, data: article });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const publishArticle = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const article = await adminService.publishArticle(req.params.id as string);
+
+    if (!article) {
+      res.status(404).json({ success: false, message: '기사를 찾을 수 없습니다.' });
+      return;
+    }
+
+    res.json({ success: true, data: article });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const deleteArticle = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const article = await adminService.deleteArticle(req.params.id as string);
+
+    if (!article) {
+      res.status(404).json({ success: false, message: '기사를 찾을 수 없습니다.' });
+      return;
+    }
+
+    res.json({ success: true, message: '기사가 삭제되었습니다.' });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/controllers/admin.controller.ts
+++ b/src/controllers/admin.controller.ts
@@ -9,6 +9,8 @@ const draftStepMap: Record<string, DraftStep> = {
   preview: DraftStep.preview,
 };
 
+const validLangStatuses = Object.values(LangStatus);
+
 // ============================================
 // 파이프라인 - 뉴스 수집
 // ============================================
@@ -70,12 +72,10 @@ export const getAdminArticles = async (req: Request, res: Response, next: NextFu
 
     const validStatuses = Object.values(ArticleStatus);
     if (status && !validStatuses.includes(status as ArticleStatus)) {
-      res
-        .status(400)
-        .json({
-          success: false,
-          message: `status는 ${validStatuses.join(', ')} 중 하나여야 합니다.`,
-        });
+      res.status(400).json({
+        success: false,
+        message: `status는 ${validStatuses.join(', ')} 중 하나여야 합니다.`,
+      });
       return;
     }
 
@@ -115,6 +115,26 @@ export const createDraftArticle = async (req: Request, res: Response, next: Next
       return;
     }
 
+    if (langStatusKo && !validLangStatuses.includes(langStatusKo as LangStatus)) {
+      res
+        .status(400)
+        .json({
+          success: false,
+          message: `langStatusKo는 ${validLangStatuses.join(', ')} 중 하나여야 합니다.`,
+        });
+      return;
+    }
+
+    if (langStatusEs && !validLangStatuses.includes(langStatusEs as LangStatus)) {
+      res
+        .status(400)
+        .json({
+          success: false,
+          message: `langStatusEs는 ${validLangStatuses.join(', ')} 중 하나여야 합니다.`,
+        });
+      return;
+    }
+
     const article = await adminService.createDraftArticle({
       titleKo,
       bodyKo,
@@ -142,6 +162,24 @@ export const updateArticle = async (req: Request, res: Response, next: NextFunct
     const body = { ...(req.body ?? {}) };
     if (body.draftStep && draftStepMap[body.draftStep]) {
       body.draftStep = draftStepMap[body.draftStep];
+    }
+    if (body.langStatusKo && !validLangStatuses.includes(body.langStatusKo as LangStatus)) {
+      res
+        .status(400)
+        .json({
+          success: false,
+          message: `langStatusKo는 ${validLangStatuses.join(', ')} 중 하나여야 합니다.`,
+        });
+      return;
+    }
+    if (body.langStatusEs && !validLangStatuses.includes(body.langStatusEs as LangStatus)) {
+      res
+        .status(400)
+        .json({
+          success: false,
+          message: `langStatusEs는 ${validLangStatuses.join(', ')} 중 하나여야 합니다.`,
+        });
+      return;
     }
     const article = await adminService.updateArticle(req.params.id as string, body);
 

--- a/src/lib/swagger.ts
+++ b/src/lib/swagger.ts
@@ -14,7 +14,7 @@ const options: swaggerJsdoc.Options = {
         description: '운영 서버 (Render)',
       },
       {
-        url: 'http://localhost:1234',
+        url: `http://localhost:${process.env.PORT || 4000}`,
         description: '개발 서버',
       },
     ],

--- a/src/routes/admin.route.ts
+++ b/src/routes/admin.route.ts
@@ -1,49 +1,49 @@
-import { Router, Request, Response } from 'express';
+import { Router } from 'express';
+import { authMiddleware, adminMiddleware } from '../middlewares/auth.middleware';
+import {
+  searchNews,
+  generateContent,
+  getAdminArticles,
+  createDraftArticle,
+  updateArticle,
+  publishArticle,
+  deleteArticle,
+} from '../controllers/admin.controller';
 
 const router = Router();
+
+router.use(authMiddleware, adminMiddleware);
 
 /**
  * @swagger
  * tags:
  *   name: Admin
- *   description: 관리자 파이프라인
+ *   description: 관리자 파이프라인 🥒
  */
 
 /**
  * @swagger
  * /api/admin/pipeline/search:
  *   post:
- *     summary: 뉴스 원문 수집 (네이버 뉴스 API 연동)
+ *     summary: 뉴스 원문 수집 (RSS)
  *     tags: [Admin]
  *     security:
  *       - bearerAuth: []
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             properties:
- *               query:
- *                 type: string
- *                 description: 검색 키워드
  *     responses:
  *       200:
- *         description: 기사 목록 반환
+ *         description: 기사 후보 목록 반환
  *       401:
  *         description: 인증 필요
  *       403:
  *         description: 관리자 권한 필요
  */
-router.post('/pipeline/search', (req: Request, res: Response) => {
-  res.json({ message: 'fetch news from naver api' });
-});
+router.post('/pipeline/search', searchNews);
 
 /**
  * @swagger
  * /api/admin/pipeline/generate:
  *   post:
- *     summary: "[AI] 기사 스페인어 번역 및 요약문 생성 (Gemini API)"
+ *     summary: "[AI] 한국어 기사 생성 또는 스페인어 번역"
  *     tags: [Admin]
  *     security:
  *       - bearerAuth: []
@@ -53,24 +53,35 @@ router.post('/pipeline/search', (req: Request, res: Response) => {
  *         application/json:
  *           schema:
  *             type: object
+ *             required: [mode]
  *             properties:
+ *               mode:
+ *                 type: string
+ *                 enum: [generate, translate]
+ *                 description: "generate(원본→한국어) | translate(한국어→스페인어)"
  *               title:
  *                 type: string
- *               summary:
+ *                 description: 원본 제목 (mode=generate 필수)
+ *               content:
  *                 type: string
+ *                 description: 원본 내용 (mode=generate 필수)
+ *               titleKo:
+ *                 type: string
+ *                 description: 한국어 제목 (mode=translate 필수)
+ *               bodyKo:
+ *                 type: string
+ *                 description: 한국어 본문 (mode=translate 필수)
  *     responses:
  *       200:
  *         description: AI 생성 결과 반환
  */
-router.post('/pipeline/generate', (req: Request, res: Response) => {
-  res.json({ message: 'generate with gemini ai' });
-});
+router.post('/pipeline/generate', generateContent);
 
 /**
  * @swagger
  * /api/admin/articles:
  *   get:
- *     summary: 전체 관리 목록 조회 (상태별 필터)
+ *     summary: 전체 기사 관리 목록 조회 (상태별 필터)
  *     tags: [Admin]
  *     security:
  *       - bearerAuth: []
@@ -80,25 +91,65 @@ router.post('/pipeline/generate', (req: Request, res: Response) => {
  *         schema:
  *           type: string
  *           enum: [DRAFT, PUBLISHED, ARCHIVED]
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
  *     responses:
  *       200:
  *         description: 성공
  *   post:
- *     summary: 생성된 데이터를 DRAFT 상태로 임시저장
+ *     summary: 기사 DRAFT 저장
  *     tags: [Admin]
  *     security:
  *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [titleKo, bodyKo, categoryId, sourceUrl]
+ *             properties:
+ *               titleKo:
+ *                 type: string
+ *               bodyKo:
+ *                 type: string
+ *               culturalNoteKo:
+ *                 type: string
+ *               titleEs:
+ *                 type: string
+ *               bodyEs:
+ *                 type: string
+ *               culturalNoteEs:
+ *                 type: string
+ *               thumbnailUrl:
+ *                 type: string
+ *               categoryId:
+ *                 type: integer
+ *               sourceUrl:
+ *                 type: string
+ *               sourceTitle:
+ *                 type: string
+ *               draftStep:
+ *                 type: string
+ *                 enum: [select, review-ko, review-es, preview]
+ *               langStatusKo:
+ *                 type: string
+ *                 enum: [pending, done]
+ *               langStatusEs:
+ *                 type: string
+ *                 enum: [pending, done]
  *     responses:
  *       201:
- *         description: 임시저장 성공
+ *         description: DRAFT 저장 성공
  */
-router.get('/articles', (req: Request, res: Response) => {
-  res.json({ message: 'get all articles (admin)' });
-});
-
-router.post('/articles', (req: Request, res: Response) => {
-  res.json({ message: 'save draft article' });
-});
+router.get('/articles', getAdminArticles);
+router.post('/articles', createDraftArticle);
 
 /**
  * @swagger
@@ -114,6 +165,30 @@ router.post('/articles', (req: Request, res: Response) => {
  *         required: true
  *         schema:
  *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               titleKo:
+ *                 type: string
+ *               bodyKo:
+ *                 type: string
+ *               titleEs:
+ *                 type: string
+ *               bodyEs:
+ *                 type: string
+ *               draftStep:
+ *                 type: string
+ *                 enum: [select, review-ko, review-es, preview]
+ *               langStatusKo:
+ *                 type: string
+ *                 enum: [pending, done]
+ *               langStatusEs:
+ *                 type: string
+ *                 enum: [pending, done]
  *     responses:
  *       200:
  *         description: 수정 성공
@@ -132,19 +207,14 @@ router.post('/articles', (req: Request, res: Response) => {
  *       200:
  *         description: 삭제 성공
  */
-router.put('/articles/:id', (req: Request, res: Response) => {
-  res.json({ message: 'update article (admin)' });
-});
-
-router.delete('/articles/:id', (req: Request, res: Response) => {
-  res.json({ message: 'delete article (admin)' });
-});
+router.put('/articles/:id', updateArticle);
+router.delete('/articles/:id', deleteArticle);
 
 /**
  * @swagger
  * /api/admin/articles/{id}/publish:
  *   patch:
- *     summary: 기사 상태를 PUBLISHED로 변경
+ *     summary: 기사 발행 (PUBLISHED 상태로 변경)
  *     tags: [Admin]
  *     security:
  *       - bearerAuth: []
@@ -158,8 +228,6 @@ router.delete('/articles/:id', (req: Request, res: Response) => {
  *       200:
  *         description: 발행 성공
  */
-router.patch('/articles/:id/publish', (req: Request, res: Response) => {
-  res.json({ message: 'publish article' });
-});
+router.patch('/articles/:id/publish', publishArticle);
 
 export default router;

--- a/src/routes/admin.route.ts
+++ b/src/routes/admin.route.ts
@@ -18,14 +18,14 @@ router.use(authMiddleware, adminMiddleware);
  * @swagger
  * tags:
  *   name: Admin
- *   description: 관리자 파이프라인 🥒
+ *   description: 관리자 파이프라인
  */
 
 /**
  * @swagger
  * /api/admin/pipeline/search:
  *   post:
- *     summary: 뉴스 원문 수집 (RSS)
+ *     summary: 뉴스 원문 수집 (RSS)🥒
  *     tags: [Admin]
  *     security:
  *       - bearerAuth: []
@@ -43,7 +43,7 @@ router.post('/pipeline/search', searchNews);
  * @swagger
  * /api/admin/pipeline/generate:
  *   post:
- *     summary: "[AI] 한국어 기사 생성 또는 스페인어 번역"
+ *     summary: "[AI] 한국어 기사 생성 또는 스페인어 번역"🥒
  *     tags: [Admin]
  *     security:
  *       - bearerAuth: []
@@ -81,7 +81,7 @@ router.post('/pipeline/generate', generateContent);
  * @swagger
  * /api/admin/articles:
  *   get:
- *     summary: 전체 기사 관리 목록 조회 (상태별 필터)
+ *     summary: 전체 기사 관리 목록 조회 (상태별 필터)🥒
  *     tags: [Admin]
  *     security:
  *       - bearerAuth: []
@@ -155,7 +155,7 @@ router.post('/articles', createDraftArticle);
  * @swagger
  * /api/admin/articles/{id}:
  *   put:
- *     summary: 기사 내용 수동 수정
+ *     summary: 기사 내용 수동 수정🥒
  *     tags: [Admin]
  *     security:
  *       - bearerAuth: []
@@ -214,7 +214,7 @@ router.delete('/articles/:id', deleteArticle);
  * @swagger
  * /api/admin/articles/{id}/publish:
  *   patch:
- *     summary: 기사 발행 (PUBLISHED 상태로 변경)
+ *     summary: 기사 발행 (PUBLISHED 상태로 변경)🥒
  *     tags: [Admin]
  *     security:
  *       - bearerAuth: []

--- a/src/routes/admin.route.ts
+++ b/src/routes/admin.route.ts
@@ -18,14 +18,34 @@ router.use(authMiddleware, adminMiddleware);
  * @swagger
  * tags:
  *   name: Admin
- *   description: 관리자 파이프라인
+ *   description: |
+ *     관리자 전용 기사 파이프라인 🥒
+ *
+ *     **기사 작성 순서**
+ *     1. `POST /pipeline/search` - 뉴스 수집 (언론사별 최신 기사 15개 반환)
+ *     2. `POST /pipeline/generate` (mode: generate) - 원본 기사 → 한국어 기사 생성
+ *     3. `POST /pipeline/generate` (mode: translate) - 한국어 기사 → 스페인어 번역
+ *     4. `POST /articles` - 생성된 내용 DB에 DRAFT 저장
+ *     5. `PATCH /articles/{id}/publish` - 검토 후 발행
  */
 
 /**
  * @swagger
  * /api/admin/pipeline/search:
  *   post:
- *     summary: 뉴스 원문 수집 (RSS)🥒
+ *     summary: "① 뉴스 수집 - 언론사별 최신 기사 15개 반환 🥒"
+ *     description: |
+ *       RSS 피드(연합뉴스, MBC, 경향신문 등)와 네이버 뉴스 API에서 기사를 수집합니다.
+ *       언론사별 최대 3개씩, 총 15개를 반환하며 이미 DB에 저장된 기사는 자동으로 제외됩니다.
+ *
+ *       반환 필드:
+ *       - `title`: 기사 제목
+ *       - `summary`: 기사 요약
+ *       - `url`: 원본 기사 URL → POST /articles의 sourceUrl에 사용
+ *       - `thumbnailUrl`: 썸네일 이미지 URL (없으면 null)
+ *       - `source`: 언론사명
+ *       - `category`: 카테고리명
+ *       - `slug`: 카테고리 슬러그 (kpop / sports / culture / news)
  *     tags: [Admin]
  *     security:
  *       - bearerAuth: []
@@ -33,9 +53,9 @@ router.use(authMiddleware, adminMiddleware);
  *       200:
  *         description: 기사 후보 목록 반환
  *       401:
- *         description: 인증 필요
+ *         description: 인증 토큰 없음
  *       403:
- *         description: 관리자 권한 필요
+ *         description: 관리자 권한 없음
  */
 router.post('/pipeline/search', searchNews);
 
@@ -43,7 +63,17 @@ router.post('/pipeline/search', searchNews);
  * @swagger
  * /api/admin/pipeline/generate:
  *   post:
- *     summary: "[AI] 한국어 기사 생성 또는 스페인어 번역"🥒
+ *     summary: "② AI 기사 생성 / 번역 🥒"
+ *     description: |
+ *       **mode: generate** - 원본 기사(title + content) → 한국어 기사 생성
+ *       - 필수값: title, content (search 결과의 title, summary 사용)
+ *       - 반환값: titleKo, bodyKo, culturalNoteKo
+ *
+ *       **mode: translate** - 한국어 기사 → 스페인어 번역
+ *       - 필수값: titleKo, bodyKo (generate 결과 사용)
+ *       - 반환값: titleEs, bodyEs, culturalNoteEs
+ *
+ *       생성된 결과는 POST /articles에 그대로 사용하면 됩니다.
  *     tags: [Admin]
  *     security:
  *       - bearerAuth: []
@@ -61,19 +91,27 @@ router.post('/pipeline/search', searchNews);
  *                 description: "generate(원본→한국어) | translate(한국어→스페인어)"
  *               title:
  *                 type: string
- *                 description: 원본 제목 (mode=generate 필수)
+ *                 description: "원본 기사 제목 (mode=generate 필수)"
  *               content:
  *                 type: string
- *                 description: 원본 내용 (mode=generate 필수)
+ *                 description: "원본 기사 내용 (mode=generate 필수)"
  *               titleKo:
  *                 type: string
- *                 description: 한국어 제목 (mode=translate 필수)
+ *                 description: "한국어 제목 (mode=translate 필수)"
  *               bodyKo:
  *                 type: string
- *                 description: 한국어 본문 (mode=translate 필수)
+ *                 description: "한국어 본문 (mode=translate 필수)"
  *     responses:
  *       200:
- *         description: AI 생성 결과 반환
+ *         description: |
+ *           generate → { titleKo, bodyKo, culturalNoteKo }
+ *           translate → { titleEs, bodyEs, culturalNoteEs }
+ *       400:
+ *         description: mode 또는 필수 필드 누락
+ *       401:
+ *         description: 인증 토큰 없음
+ *       403:
+ *         description: 관리자 권한 없음
  */
 router.post('/pipeline/generate', generateContent);
 
@@ -81,7 +119,8 @@ router.post('/pipeline/generate', generateContent);
  * @swagger
  * /api/admin/articles:
  *   get:
- *     summary: 전체 기사 관리 목록 조회 (상태별 필터)🥒
+ *     summary: "기사 목록 조회 (상태별 필터) 🥒"
+ *     description: 관리자용 전체 기사 목록입니다. status로 필터링하고 page/limit으로 페이지네이션할 수 있습니다.
  *     tags: [Admin]
  *     security:
  *       - bearerAuth: []
@@ -91,19 +130,34 @@ router.post('/pipeline/generate', generateContent);
  *         schema:
  *           type: string
  *           enum: [DRAFT, PUBLISHED, ARCHIVED]
+ *         description: "미입력 시 전체 조회"
  *       - in: query
  *         name: page
  *         schema:
  *           type: integer
+ *           default: 1
  *       - in: query
  *         name: limit
  *         schema:
  *           type: integer
+ *           default: 20
  *     responses:
  *       200:
- *         description: 성공
+ *         description: "{ articles, pagination: { total, page, limit, totalPages } }"
  *   post:
- *     summary: 기사 DRAFT 저장
+ *     summary: "③ 기사 DRAFT 저장 🥒"
+ *     description: |
+ *       generate/translate 결과를 조합해서 DB에 저장합니다.
+ *
+ *       **draftStep** - 현재 파이프라인 단계
+ *       - select: 기사 선택 단계
+ *       - review-ko: 한국어 검토 단계
+ *       - review-es: 스페인어 검토 단계
+ *       - preview: 최종 미리보기 (발행 직전)
+ *
+ *       **langStatusKo / langStatusEs** - 각 언어 작성 완료 여부
+ *       - pending: 미완성
+ *       - done: 완성
  *     tags: [Admin]
  *     security:
  *       - bearerAuth: []
@@ -117,36 +171,51 @@ router.post('/pipeline/generate', generateContent);
  *             properties:
  *               titleKo:
  *                 type: string
+ *                 description: "한국어 제목 (필수)"
  *               bodyKo:
  *                 type: string
+ *                 description: "한국어 본문 (필수)"
  *               culturalNoteKo:
  *                 type: string
+ *                 description: "한국어 한줄 요약"
  *               titleEs:
  *                 type: string
+ *                 description: "스페인어 제목"
  *               bodyEs:
  *                 type: string
+ *                 description: "스페인어 본문"
  *               culturalNoteEs:
  *                 type: string
+ *                 description: "스페인어 한줄 요약"
  *               thumbnailUrl:
  *                 type: string
+ *                 description: "썸네일 이미지 URL (search 결과의 thumbnailUrl 사용)"
  *               categoryId:
  *                 type: integer
+ *                 description: "카테고리 ID (필수)"
  *               sourceUrl:
  *                 type: string
+ *                 description: "원본 기사 URL (필수, search 결과의 url 사용)"
  *               sourceTitle:
  *                 type: string
+ *                 description: "원본 기사 제목 (search 결과의 title 사용)"
  *               draftStep:
  *                 type: string
  *                 enum: [select, review-ko, review-es, preview]
+ *                 description: "현재 파이프라인 단계 (기본값: select)"
  *               langStatusKo:
  *                 type: string
  *                 enum: [pending, done]
+ *                 description: "한국어 작성 완료 여부 (기본값: pending)"
  *               langStatusEs:
  *                 type: string
  *                 enum: [pending, done]
+ *                 description: "스페인어 작성 완료 여부 (기본값: pending)"
  *     responses:
  *       201:
  *         description: DRAFT 저장 성공
+ *       400:
+ *         description: 필수 필드 누락 또는 유효하지 않은 값
  */
 router.get('/articles', getAdminArticles);
 router.post('/articles', createDraftArticle);
@@ -155,7 +224,8 @@ router.post('/articles', createDraftArticle);
  * @swagger
  * /api/admin/articles/{id}:
  *   put:
- *     summary: 기사 내용 수동 수정🥒
+ *     summary: "기사 내용 수동 수정 🥒"
+ *     description: 저장된 기사 내용을 수정합니다. 수정할 필드만 포함해서 보내면 됩니다.
  *     tags: [Admin]
  *     security:
  *       - bearerAuth: []
@@ -165,6 +235,7 @@ router.post('/articles', createDraftArticle);
  *         required: true
  *         schema:
  *           type: string
+ *         description: 기사 UUID
  *     requestBody:
  *       required: true
  *       content:
@@ -176,9 +247,13 @@ router.post('/articles', createDraftArticle);
  *                 type: string
  *               bodyKo:
  *                 type: string
+ *               culturalNoteKo:
+ *                 type: string
  *               titleEs:
  *                 type: string
  *               bodyEs:
+ *                 type: string
+ *               culturalNoteEs:
  *                 type: string
  *               draftStep:
  *                 type: string
@@ -192,8 +267,13 @@ router.post('/articles', createDraftArticle);
  *     responses:
  *       200:
  *         description: 수정 성공
+ *       400:
+ *         description: 유효하지 않은 값
+ *       404:
+ *         description: 기사를 찾을 수 없음
  *   delete:
- *     summary: 기사 영구 삭제
+ *     summary: "기사 영구 삭제 🥒"
+ *     description: 기사를 DB에서 완전히 삭제합니다. 복구 불가능합니다.
  *     tags: [Admin]
  *     security:
  *       - bearerAuth: []
@@ -203,9 +283,12 @@ router.post('/articles', createDraftArticle);
  *         required: true
  *         schema:
  *           type: string
+ *         description: 기사 UUID
  *     responses:
  *       200:
  *         description: 삭제 성공
+ *       404:
+ *         description: 기사를 찾을 수 없음
  */
 router.put('/articles/:id', updateArticle);
 router.delete('/articles/:id', deleteArticle);
@@ -214,7 +297,11 @@ router.delete('/articles/:id', deleteArticle);
  * @swagger
  * /api/admin/articles/{id}/publish:
  *   patch:
- *     summary: 기사 발행 (PUBLISHED 상태로 변경)🥒
+ *     summary: "⑤ 기사 발행 🥒"
+ *     description: |
+ *       기사 상태를 PUBLISHED로 변경하고 publishedAt을 현재 시각으로 설정합니다.
+ *       발행된 기사는 GET /api/articles에서 일반 사용자에게 노출됩니다.
+ *       이미 발행된 기사는 중복 발행되지 않습니다.
  *     tags: [Admin]
  *     security:
  *       - bearerAuth: []
@@ -224,9 +311,12 @@ router.delete('/articles/:id', deleteArticle);
  *         required: true
  *         schema:
  *           type: string
+ *         description: 기사 UUID
  *     responses:
  *       200:
  *         description: 발행 성공
+ *       404:
+ *         description: 기사를 찾을 수 없음
  */
 router.patch('/articles/:id/publish', publishArticle);
 

--- a/src/services/admin.service.ts
+++ b/src/services/admin.service.ts
@@ -1,0 +1,441 @@
+import { ArticleStatus, DraftStep, LangStatus, Prisma } from '@prisma/client';
+import { prisma } from '../lib/prisma';
+import { GoogleGenAI } from '@google/genai';
+import Parser from 'rss-parser';
+
+interface NewsArticle {
+  title: string;
+  summary: string | undefined;
+  url: string;
+  source: string;
+  category: string;
+  slug: string;
+  publishedAt?: string;
+  thumbnailUrl: string | null;
+}
+
+interface NaverNewsResponse {
+  items: {
+    title: string;
+    description: string;
+    originallink: string;
+    link: string;
+    pubDate: string;
+  }[];
+}
+
+interface RssItem {
+  title: string;
+  contentSnippet?: string;
+  link: string;
+  pubDate?: string;
+  mediaContent?: { $: { url: string } };
+  mediaThumbnail?: { $: { url: string } };
+  enclosure?: { url: string };
+}
+
+const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY! });
+
+const rssParser = new Parser({
+  customFields: {
+    item: [
+      ['media:content', 'mediaContent'],
+      ['media:thumbnail', 'mediaThumbnail'],
+      ['enclosure', 'enclosure'],
+    ],
+  },
+});
+
+const RSS_FEEDS = [
+  {
+    url: 'https://www.yna.co.kr/rss/entertainment.xml',
+    source: '연합뉴스',
+    category: 'K-POP',
+    slug: 'kpop',
+  },
+  {
+    url: 'https://www.yna.co.kr/rss/sports.xml',
+    source: '연합뉴스',
+    category: '스포츠',
+    slug: 'sports',
+  },
+  {
+    url: 'https://www.yna.co.kr/rss/culture.xml',
+    source: '연합뉴스',
+    category: '문화',
+    slug: 'culture',
+  },
+  {
+    url: 'https://www.yna.co.kr/rss/politics.xml',
+    source: '연합뉴스',
+    category: '뉴스',
+    slug: 'news',
+  },
+  {
+    url: 'https://imnews.imbc.com/rss/news/news_00.xml',
+    source: 'MBC',
+    category: '뉴스',
+    slug: 'news',
+  },
+  {
+    url: 'https://www.mk.co.kr/rss/30000023/',
+    source: '매일경제',
+    category: 'K-POP',
+    slug: 'kpop',
+  },
+  {
+    url: 'https://isplus.com/rss/index.html',
+    source: '일간스포츠',
+    category: 'K-POP',
+    slug: 'kpop',
+  },
+  {
+    url: 'https://www.khan.co.kr/rss/rssdata/kh_sports.xml',
+    source: '경향신문',
+    category: '스포츠',
+    slug: 'sports',
+  },
+  {
+    url: 'https://star.mt.co.kr/rss/rankingRss.xml',
+    source: '스타뉴스',
+    category: 'K-POP',
+    slug: 'kpop',
+  },
+];
+
+const NAVER_KEYWORDS = [
+  { keyword: 'K-POP 신보', slug: 'kpop', category: 'K-POP' },
+  { keyword: '한류 콘서트', slug: 'kpop', category: 'K-POP' },
+  { keyword: '아이돌 컴백', slug: 'kpop', category: 'K-POP' },
+  { keyword: '케이팝 차트', slug: 'kpop', category: 'K-POP' },
+  { keyword: '한국드라마 OTT', slug: 'culture', category: '문화' },
+  { keyword: '한국 스포츠', slug: 'sports', category: '스포츠' },
+];
+
+const fetchNaverNews = async () => {
+  const clientId = process.env.NAVER_CLIENT_ID;
+  const clientSecret = process.env.NAVER_CLIENT_SECRET;
+  if (!clientId || !clientSecret) return [];
+
+  const results = await Promise.allSettled(
+    NAVER_KEYWORDS.map(async ({ keyword, slug, category }) => {
+      const url = `https://openapi.naver.com/v1/search/news.json?query=${encodeURIComponent(keyword)}&display=5&sort=date`;
+      const res = await fetch(url, {
+        headers: {
+          'X-Naver-Client-Id': clientId,
+          'X-Naver-Client-Secret': clientSecret,
+        },
+      });
+      const data = (await res.json()) as NaverNewsResponse;
+      return { slug, category, items: data.items ?? [] };
+    }),
+  );
+
+  const articles: NewsArticle[] = [];
+  for (const result of results) {
+    if (result.status === 'fulfilled') {
+      const { slug, category, items } = result.value;
+      items.forEach((item) => {
+        articles.push({
+          title: item.title.replace(/<[^>]+>/g, ''),
+          summary: item.description.replace(/<[^>]+>/g, ''),
+          url: item.originallink || item.link,
+          source: '네이버뉴스',
+          category,
+          slug,
+          publishedAt: item.pubDate,
+          thumbnailUrl: null,
+        });
+      });
+    }
+  }
+  return articles;
+};
+
+export const searchNews = async () => {
+  const [feedResults, naverArticles] = await Promise.all([
+    Promise.allSettled(
+      RSS_FEEDS.map((feed) =>
+        rssParser.parseURL(feed.url).then((r) => ({ feed, items: r.items as RssItem[] })),
+      ),
+    ),
+    fetchNaverNews(),
+  ]);
+
+  const articles: NewsArticle[] = [];
+
+  for (const result of feedResults) {
+    if (result.status === 'fulfilled') {
+      const { feed, items } = result.value;
+      items.slice(0, 5).forEach((item) => {
+        const decodeEntities = (str: string) =>
+          str
+            .replace(/&quot;/g, '"')
+            .replace(/&amp;/g, '&')
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .replace(/&#39;/g, "'");
+        articles.push({
+          title: decodeEntities(item.title),
+          summary: item.contentSnippet ? decodeEntities(item.contentSnippet) : undefined,
+          url: item.link,
+          source: feed.source,
+          category: feed.category,
+          slug: feed.slug,
+          publishedAt: item.pubDate,
+          thumbnailUrl:
+            item.mediaContent?.$.url || item.mediaThumbnail?.$.url || item.enclosure?.url || null,
+        });
+      });
+    }
+  }
+
+  articles.push(...naverArticles);
+
+  const urls = articles.map((a) => a.url).filter(Boolean);
+  const existing = await prisma.articleSource.findMany({
+    where: { url: { in: urls } },
+    select: { url: true },
+  });
+  const existingUrls = new Set(existing.map((s) => s.url));
+  const filtered = articles.filter((a) => !existingUrls.has(a.url));
+
+  const seenUrls = new Set<string>();
+  const deduped = filtered.filter((a) => {
+    if (seenUrls.has(a.url)) return false;
+    seenUrls.add(a.url);
+    return true;
+  });
+
+  const sourceMap = new Map<string, NewsArticle[]>();
+  for (const article of deduped) {
+    if (!sourceMap.has(article.source)) sourceMap.set(article.source, []);
+    sourceMap.get(article.source)!.push(article);
+  }
+  for (const group of sourceMap.values()) {
+    for (let i = group.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [group[i], group[j]] = [group[j], group[i]];
+    }
+  }
+
+  const sources = [...sourceMap.values()];
+  const counts = new Array(sources.length).fill(0);
+  const indices = new Array(sources.length).fill(0);
+  const selected: NewsArticle[] = [];
+
+  while (selected.length < 15) {
+    let added = false;
+    for (let i = 0; i < sources.length; i++) {
+      if (selected.length >= 15) break;
+      if (counts[i] >= 3) continue;
+      if (indices[i] < sources[i].length) {
+        selected.push(sources[i][indices[i]]);
+        indices[i]++;
+        counts[i]++;
+        added = true;
+      }
+    }
+    if (!added) break;
+  }
+
+  return selected;
+};
+
+export const generateContent = async (
+  mode: 'generate' | 'translate',
+  data: {
+    title?: string;
+    content?: string;
+    titleKo?: string;
+    bodyKo?: string;
+  },
+) => {
+  let prompt = '';
+
+  if (mode === 'generate') {
+    prompt = `
+      다음은 한국 뉴스 기사야.
+
+      제목: ${data.title}
+      내용: ${data.content}
+
+      위 내용을 바탕으로 아래 형식에 맞게 한국어 기사를 작성해줘.
+      친숙한 말투로 작성하고, 우리 프로젝트의 마스코트는 오이야.
+
+      [제목-KO]
+      한국어 제목
+
+      [본문-KO]
+      핵심 내용 중심으로 3~4문단, 각 문단 2~3문장, 외국인 친구에게 설명하는 느낌으로
+
+      [요약-KO]
+      한국어 한줄 요약
+    `;
+  } else {
+    prompt = `
+      다음은 한국어 기사야. 스페인어(중남미)로 자연스럽게 번역해줘.
+
+      제목: ${data.titleKo}
+      본문: ${data.bodyKo}
+
+      아래 형식을 정확히 지켜서 출력해줘:
+
+      [제목-ES]
+      Título en español
+
+      [본문-ES]
+      Cuerpo del artículo en español, 3~4 párrafos, 2~3 oraciones cada uno
+
+      [요약-ES]
+      Resumen en una oración
+    `;
+  }
+
+  let text = '';
+  for (let attempt = 1; attempt <= 5; attempt++) {
+    try {
+      const result = await ai.models.generateContent({
+        model: 'gemma-4-31b-it',
+        contents: prompt,
+      });
+      text = result.text ?? '';
+      if (!text) throw new Error('AI 응답이 비어있습니다.');
+      break;
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : '';
+      const is503 = msg.includes('503') || msg.includes('UNAVAILABLE');
+      const is429 = msg.includes('429') || msg.includes('RESOURCE_EXHAUSTED');
+      if (attempt < 5 && (is503 || is429)) {
+        const delay = attempt * 15000;
+        console.log(
+          `⚠️  ${is429 ? '429' : '503'} 에러, ${delay / 1000}초 후 재시도... (${attempt}/5)`,
+        );
+        await new Promise((r) => setTimeout(r, delay));
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  const extract = (tag: string) => {
+    const regex = new RegExp(`\\[${tag}\\]\\s*([\\s\\S]*?)(?=\\[|$)`);
+    return text.match(regex)?.[1]?.trim() ?? '';
+  };
+
+  if (mode === 'generate') {
+    return {
+      titleKo: extract('제목-KO'),
+      bodyKo: extract('본문-KO'),
+      culturalNoteKo: extract('요약-KO'),
+    };
+  } else {
+    return {
+      titleEs: extract('제목-ES'),
+      bodyEs: extract('본문-ES'),
+      culturalNoteEs: extract('요약-ES'),
+    };
+  }
+};
+
+export const getAdminArticles = async (status?: ArticleStatus, page = 1, limit = 20) => {
+  const where: Prisma.ArticleWhereInput = status ? { status } : {};
+  const skip = (page - 1) * limit;
+
+  const [articles, total] = await Promise.all([
+    prisma.article.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      skip,
+      take: limit,
+      select: {
+        id: true,
+        titleKo: true,
+        titleEs: true,
+        status: true,
+        draftStep: true,
+        langStatusKo: true,
+        langStatusEs: true,
+        viewCount: true,
+        publishedAt: true,
+        createdAt: true,
+        updatedAt: true,
+        category: { select: { id: true, name: true, slug: true } },
+        _count: { select: { likes: true, comments: true } },
+      },
+    }),
+    prisma.article.count({ where }),
+  ]);
+
+  return { articles, pagination: { total, page, limit, totalPages: Math.ceil(total / limit) } };
+};
+
+export const createDraftArticle = async (data: {
+  titleKo: string;
+  bodyKo: string;
+  culturalNoteKo?: string;
+  titleEs?: string;
+  bodyEs?: string;
+  culturalNoteEs?: string;
+  thumbnailUrl?: string;
+  categoryId: number;
+  sourceUrl: string;
+  sourceTitle?: string;
+  draftStep?: DraftStep;
+  langStatusKo?: LangStatus;
+  langStatusEs?: LangStatus;
+}) => {
+  return prisma.article.create({
+    data: {
+      titleKo: data.titleKo,
+      bodyKo: data.bodyKo,
+      culturalNoteKo: data.culturalNoteKo,
+      titleEs: data.titleEs,
+      bodyEs: data.bodyEs,
+      culturalNoteEs: data.culturalNoteEs,
+      thumbnailUrl: data.thumbnailUrl,
+      categoryId: data.categoryId,
+      status: 'DRAFT',
+      draftStep: data.draftStep ?? 'select',
+      langStatusKo: data.langStatusKo ?? 'pending',
+      langStatusEs: data.langStatusEs ?? 'pending',
+      sources: {
+        create: { url: data.sourceUrl, title: data.sourceTitle },
+      },
+    },
+    include: { category: true, sources: true },
+  });
+};
+
+export const updateArticle = async (id: string, data: Prisma.ArticleUpdateInput) => {
+  const article = await prisma.article.findUnique({ where: { id } });
+  if (!article) return null;
+
+  return prisma.article.update({
+    where: { id },
+    data,
+    include: { category: true, sources: true },
+  });
+};
+
+export const publishArticle = async (id: string) => {
+  const article = await prisma.article.findUnique({ where: { id } });
+  if (!article) return null;
+  if (article.status === 'PUBLISHED') return article;
+
+  return prisma.article.update({
+    where: { id },
+    data: {
+      status: 'PUBLISHED',
+      draftStep: 'preview',
+      publishedAt: new Date(),
+    },
+  });
+};
+
+export const deleteArticle = async (id: string) => {
+  const article = await prisma.article.findUnique({ where: { id } });
+  if (!article) return null;
+
+  return prisma.article.delete({ where: { id } });
+};

--- a/src/services/admin.service.ts
+++ b/src/services/admin.service.ts
@@ -386,6 +386,11 @@ export const createDraftArticle = async (data: {
   langStatusKo?: LangStatus;
   langStatusEs?: LangStatus;
 }) => {
+  const existingSource = await prisma.articleSource.findFirst({
+    where: { url: data.sourceUrl },
+  });
+  if (existingSource) return null;
+
   return prisma.article.create({
     data: {
       titleKo: data.titleKo,

--- a/src/services/admin.service.ts
+++ b/src/services/admin.service.ts
@@ -126,6 +126,7 @@ const fetchNaverNews = async () => {
           'X-Naver-Client-Secret': clientSecret,
         },
       });
+      if (!res.ok) return { slug, category, items: [] };
       const data = (await res.json()) as NaverNewsResponse;
       return { slug, category, items: data.items ?? [] };
     }),


### PR DESCRIPTION
closes #14 

## 작업 내용
뉴스 수집부터 발행까지 전체 흐름 구현
- RSS 9개 + 네이버 API로 뉴스 수집, 언론사별 최대 3개씩 15개 선별
- AI 한국어 생성 → 스페인어 번역 → DB 저장 → 발행
- 이미 저장된 기사 자동 필터링, 중복 제거

## 체크리스트
- [ ] 뉴스 수집 → 생성 → 번역 → 저장 → 발행 전체 흐름 확인
- [ ] 이미 저장된 기사 search 결과에서 제외되는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 관리자: 다수 소스 통합 뉴스 검색(중복 제거·공정 선택)
  * AI 기반 콘텐츠 생성 및 번역(재시도 로직 포함)
  * 기사 관리: 초안 생성/수정, 게시(멱등), 삭제, 상태 필터링·페이징 목록

* **Documentation**
  * 관리자 API 엔드포인트 및 요청 스키마 문서 확장

* **Chores**
  * 로컬 개발 서버 URL을 환경에 맞게 동적 처리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->