### PR TITLE
fix: 피드백 푀소 글자수 제한

### DIFF
--- a/src/controllers/feedback.controller.ts
+++ b/src/controllers/feedback.controller.ts
@@ -15,6 +15,11 @@ export const submitFeedback = async (req: Request, res: Response, next: NextFunc
     }
 
     // 글자수 제한
+    if (body.length < 10) {
+      res.status(400).json({ success: false, message: '내용은 10자 이상 입력해주세요.' });
+      return;
+    }
+
     if (body.length > 1000) {
       res.status(400).json({ success: false, message: '내용은 1000자 이하로 입력해주세요.' });
       return;

--- a/src/controllers/feedback.controller.ts
+++ b/src/controllers/feedback.controller.ts
@@ -15,7 +15,7 @@ export const submitFeedback = async (req: Request, res: Response, next: NextFunc
     }
 
     // 글자수 제한
-    if (body.length < 10) {
+    if (body.trim().length < 10) {
       res.status(400).json({ success: false, message: '내용은 10자 이상 입력해주세요.' });
       return;
     }


### PR DESCRIPTION
closes #없서

## 작업 내용
피드백 내용에 안전장치로 최소 글자수 10자 제한을 추가했습니다.

## 체크리스트
- [ ] 로컬 동작 확인
- [ ] ESLint 오류 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 피드백 제출 시 내용이 공백을 제외해 10자 미만이면 제출이 거부되고 명확한 오류 메시지('내용은 10자 이상 입력해주세요.')가 반환됩니다. 기존의 최대 길이 제한(1000자) 및 카테고리 관련 검증은 그대로 유지되어 잘못된 제출을 더 정확히 차단합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->