### PR TITLE
feat: 댓글 기능 추가

### DIFF
--- a/src/controllers/comment.controller.ts
+++ b/src/controllers/comment.controller.ts
@@ -1,0 +1,123 @@
+import { Request, Response, NextFunction } from 'express';
+import * as commentService from '../services/comment.service';
+
+export const getComments = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const comments = await commentService.getComments(req.params.id as string);
+    res.json({ success: true, data: comments });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const createComment = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { body } = req.body ?? {};
+    const userId = req.user?.userId;
+
+    if (!userId) {
+      res.status(401).json({ success: false, message: '인증이 필요합니다.' });
+      return;
+    }
+
+    if (!body || typeof body !== 'string' || !body.trim()) {
+      res.status(400).json({ success: false, message: '댓글 내용을 입력해주세요.' });
+      return;
+    }
+
+    if (body.trim().length < 10) {
+      res.status(400).json({ success: false, message: '댓글은 10자 이상 입력해주세요.' });
+      return;
+    }
+
+    if (body.trim().length > 400) {
+      res.status(400).json({ success: false, message: '댓글은 400자 이하로 입력해주세요.' });
+      return;
+    }
+
+    const comment = await commentService.createComment(
+      req.params.id as string,
+      userId,
+      body.trim(),
+    );
+
+    if (!comment) {
+      res.status(404).json({ success: false, message: '기사를 찾을 수 없습니다.' });
+      return;
+    }
+
+    res.status(201).json({ success: true, data: comment });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const updateComment = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { body } = req.body ?? {};
+    const userId = req.user?.userId;
+
+    if (!userId) {
+      res.status(401).json({ success: false, message: '인증이 필요합니다.' });
+      return;
+    }
+
+    if (!body || typeof body !== 'string' || !body.trim()) {
+      res.status(400).json({ success: false, message: '댓글 내용을 입력해주세요.' });
+      return;
+    }
+
+    if (body.trim().length < 10) {
+      res.status(400).json({ success: false, message: '댓글은 10자 이상 입력해주세요.' });
+      return;
+    }
+
+    if (body.trim().length > 400) {
+      res.status(400).json({ success: false, message: '댓글은 400자 이하로 입력해주세요.' });
+      return;
+    }
+
+    const result = await commentService.updateComment(req.params.id as string, userId, body.trim());
+
+    if (!result) {
+      res.status(404).json({ success: false, message: '댓글을 찾을 수 없습니다.' });
+      return;
+    }
+
+    if (result === 'forbidden') {
+      res.status(403).json({ success: false, message: '본인 댓글만 수정할 수 있습니다.' });
+      return;
+    }
+
+    res.json({ success: true, data: result });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const deleteComment = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = req.user?.userId;
+
+    if (!userId) {
+      res.status(401).json({ success: false, message: '인증이 필요합니다.' });
+      return;
+    }
+
+    const result = await commentService.deleteComment(req.params.id as string, userId);
+
+    if (!result) {
+      res.status(404).json({ success: false, message: '댓글을 찾을 수 없습니다.' });
+      return;
+    }
+
+    if (result === 'forbidden') {
+      res.status(403).json({ success: false, message: '본인 댓글만 삭제할 수 있습니다.' });
+      return;
+    }
+
+    res.json({ success: true, message: '댓글이 삭제되었습니다.' });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/routes/articles.route.ts
+++ b/src/routes/articles.route.ts
@@ -1,5 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { getArticlesController, getArticleController } from '../controllers/article.controller';
+import { getComments, createComment } from '../controllers/comment.controller';
+import { authMiddleware } from '../middlewares/auth.middleware';
 
 const router = Router();
 
@@ -119,7 +121,7 @@ router.post('/:id/scrap', (req: Request, res: Response) => {
  * @swagger
  * /api/articles/{id}/comments:
  *   get:
- *     summary: 특정 기사의 댓글 리스트 조회
+ *     summary: 특정 기사의 댓글 리스트 조회 🥒
  *     tags: [Articles]
  *     parameters:
  *       - in: path
@@ -131,7 +133,7 @@ router.post('/:id/scrap', (req: Request, res: Response) => {
  *       200:
  *         description: 성공
  *   post:
- *     summary: 댓글 작성
+ *     summary: 댓글 작성 🥒
  *     tags: [Articles]
  *     security:
  *       - bearerAuth: []
@@ -156,11 +158,7 @@ router.post('/:id/scrap', (req: Request, res: Response) => {
  *       401:
  *         description: 인증 필요
  */
-router.get('/:id/comments', (req: Request, res: Response) => {
-  res.json({ message: 'get comments' });
-});
-router.post('/:id/comments', (req: Request, res: Response) => {
-  res.json({ message: 'create comment' });
-});
+router.get('/:id/comments', getComments);
+router.post('/:id/comments', authMiddleware, createComment);
 
 export default router;

--- a/src/routes/comments.route.ts
+++ b/src/routes/comments.route.ts
@@ -1,4 +1,6 @@
-import { Router, Request, Response } from 'express';
+import { Router } from 'express';
+import { updateComment, deleteComment } from '../controllers/comment.controller';
+import { authMiddleware } from '../middlewares/auth.middleware';
 
 const router = Router();
 
@@ -13,7 +15,7 @@ const router = Router();
  * @swagger
  * /api/comments/{id}:
  *   put:
- *     summary: 댓글 수정 (본인만)
+ *     summary: 댓글 수정 (본인만) 🥒
  *     tags: [Comments]
  *     security:
  *       - bearerAuth: []
@@ -40,7 +42,7 @@ const router = Router();
  *       403:
  *         description: 권한 없음
  *   delete:
- *     summary: 댓글 삭제 (본인만)
+ *     summary: 댓글 삭제 (본인만) 🥒
  *     tags: [Comments]
  *     security:
  *       - bearerAuth: []
@@ -58,12 +60,7 @@ const router = Router();
  *       403:
  *         description: 권한 없음
  */
-router.put('/:id', (req: Request, res: Response) => {
-  res.json({ message: 'update comment' });
-});
-
-router.delete('/:id', (req: Request, res: Response) => {
-  res.json({ message: 'delete comment' });
-});
+router.put('/:id', authMiddleware, updateComment);
+router.delete('/:id', authMiddleware, deleteComment);
 
 export default router;

--- a/src/services/comment.service.ts
+++ b/src/services/comment.service.ts
@@ -38,7 +38,7 @@ export const createComment = async (articleId: string, userId: string, body: str
 };
 
 export const updateComment = async (commentId: string, userId: string, body: string) => {
-  const comment = await prisma.comment.findUnique({
+  const comment = await prisma.comment.findFirst({
     where: { id: commentId, deletedAt: null },
   });
   if (!comment) return null;
@@ -60,7 +60,7 @@ export const updateComment = async (commentId: string, userId: string, body: str
 };
 
 export const deleteComment = async (commentId: string, userId: string) => {
-  const comment = await prisma.comment.findUnique({
+  const comment = await prisma.comment.findFirst({
     where: { id: commentId, deletedAt: null },
   });
   if (!comment) return null;

--- a/src/services/comment.service.ts
+++ b/src/services/comment.service.ts
@@ -1,0 +1,73 @@
+import { prisma } from '../lib/prisma';
+
+export const getComments = async (articleId: string) => {
+  return prisma.comment.findMany({
+    where: {
+      articleId,
+      deletedAt: null,
+    },
+    orderBy: { createdAt: 'asc' },
+    select: {
+      id: true,
+      body: true,
+      createdAt: true,
+      updatedAt: true,
+      user: {
+        select: { id: true, nickname: true, avatarEmoji: true },
+      },
+    },
+  });
+};
+
+export const createComment = async (articleId: string, userId: string, body: string) => {
+  const article = await prisma.article.findUnique({ where: { id: articleId } });
+  if (!article) return null;
+
+  return prisma.comment.create({
+    data: { articleId, userId, body },
+    select: {
+      id: true,
+      body: true,
+      createdAt: true,
+      updatedAt: true,
+      user: {
+        select: { id: true, nickname: true, avatarEmoji: true },
+      },
+    },
+  });
+};
+
+export const updateComment = async (commentId: string, userId: string, body: string) => {
+  const comment = await prisma.comment.findUnique({
+    where: { id: commentId, deletedAt: null },
+  });
+  if (!comment) return null;
+  if (comment.userId !== userId) return 'forbidden';
+
+  return prisma.comment.update({
+    where: { id: commentId },
+    data: { body, updatedAt: new Date() },
+    select: {
+      id: true,
+      body: true,
+      createdAt: true,
+      updatedAt: true,
+      user: {
+        select: { id: true, nickname: true, avatarEmoji: true },
+      },
+    },
+  });
+};
+
+export const deleteComment = async (commentId: string, userId: string) => {
+  const comment = await prisma.comment.findUnique({
+    where: { id: commentId, deletedAt: null },
+  });
+  if (!comment) return null;
+  if (comment.userId !== userId) return 'forbidden';
+
+  return prisma.comment.update({
+    where: { id: commentId },
+    data: { deletedAt: new Date() },
+  });
+};


### PR DESCRIPTION
closes #19 

## 작업 내용
댓글 기능 구현

GET /api/articles/:id/comments - 댓글 조회 (인증 불필요, 소프트 삭제된 댓글 제외)
POST /api/articles/:id/comments - 댓글 작성 (로그인 필요, 10자~400자)
PUT /api/comments/:id - 댓글 수정 (본인만, 10자~400자)
DELETE /api/comments/:id - 댓글 삭제 (본인만, 소프트 삭제)

## 체크리스트
- [ ] 로컬 동작 확인
- [ ] ESLint 오류 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 게시글별 댓글 조회, 생성, 수정, 삭제 기능 추가(생성/수정/삭제는 인증 필요).
  * 댓글은 작성자만 수정/삭제 가능하며 삭제는 소프트 삭제로 처리.
  * 댓글 목록은 생성 시각 순으로 제공.

* **제한/검증**
  * 댓글 내용은 공백 제거 후 최소 10자, 최대 400자 제한.
  * 존재하지 않거나 권한 없는 조작에 대해 적절한 오류 응답 제공.

* **문서**
  * API 설명(요약) 문구 업데이트 (식별용 이모지 포함).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->