### PR TITLE
feat: 기사 좋아요 api 추가

### DIFF
--- a/src/controllers/like.controller.ts
+++ b/src/controllers/like.controller.ts
@@ -1,0 +1,24 @@
+import { Request, Response, NextFunction } from 'express';
+import * as likeService from '../services/like.service';
+
+export const toggleLike = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = req.user?.userId;
+
+    if (!userId) {
+      res.status(401).json({ success: false, message: '인증이 필요합니다.' });
+      return;
+    }
+
+    const result = await likeService.toggleLike(req.params.id as string, userId);
+
+    if (!result) {
+      res.status(404).json({ success: false, message: '기사를 찾을 수 없습니다.' });
+      return;
+    }
+
+    res.json({ success: true, data: result });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/routes/articles.route.ts
+++ b/src/routes/articles.route.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { getArticlesController, getArticleController } from '../controllers/article.controller';
 import { getComments, createComment } from '../controllers/comment.controller';
+import { toggleLike } from '../controllers/like.controller';
 import { authMiddleware } from '../middlewares/auth.middleware';
 
 const router = Router();
@@ -73,7 +74,7 @@ router.get('/:id', getArticleController);
  * @swagger
  * /api/articles/{id}/like:
  *   post:
- *     summary: 좋아요 토글 (생성/삭제)
+ *     summary: 좋아요 토글 (생성/삭제)🥒
  *     tags: [Articles]
  *     security:
  *       - bearerAuth: []
@@ -89,33 +90,7 @@ router.get('/:id', getArticleController);
  *       401:
  *         description: 인증 필요
  */
-router.post('/:id/like', (req: Request, res: Response) => {
-  res.json({ message: 'toggle like' });
-});
-
-/**
- * @swagger
- * /api/articles/{id}/scrap:
- *   post:
- *     summary: 스크랩 토글 (생성/삭제)
- *     tags: [Articles]
- *     security:
- *       - bearerAuth: []
- *     parameters:
- *       - in: path
- *         name: id
- *         required: true
- *         schema:
- *           type: string
- *     responses:
- *       200:
- *         description: 성공
- *       401:
- *         description: 인증 필요
- */
-router.post('/:id/scrap', (req: Request, res: Response) => {
-  res.json({ message: 'toggle scrap' });
-});
+router.post('/:id/like', authMiddleware, toggleLike);
 
 /**
  * @swagger

--- a/src/services/like.service.ts
+++ b/src/services/like.service.ts
@@ -1,22 +1,20 @@
+import { Prisma } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 
 export const toggleLike = async (articleId: string, userId: string) => {
   const article = await prisma.article.findUnique({ where: { id: articleId } });
   if (!article) return null;
 
-  const existing = await prisma.like.findUnique({
-    where: { userId_articleId: { userId, articleId } },
-  });
-
-  if (existing) {
-    await prisma.like.delete({
-      where: { userId_articleId: { userId, articleId } },
-    });
-    return { liked: false };
-  } else {
-    await prisma.like.create({
-      data: { userId, articleId },
-    });
+  try {
+    await prisma.like.create({ data: { userId, articleId } });
     return { liked: true };
+  } catch (e) {
+    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
+      await prisma.like.delete({
+        where: { userId_articleId: { userId, articleId } },
+      });
+      return { liked: false };
+    }
+    throw e;
   }
 };

--- a/src/services/like.service.ts
+++ b/src/services/like.service.ts
@@ -1,0 +1,22 @@
+import { prisma } from '../lib/prisma';
+
+export const toggleLike = async (articleId: string, userId: string) => {
+  const article = await prisma.article.findUnique({ where: { id: articleId } });
+  if (!article) return null;
+
+  const existing = await prisma.like.findUnique({
+    where: { userId_articleId: { userId, articleId } },
+  });
+
+  if (existing) {
+    await prisma.like.delete({
+      where: { userId_articleId: { userId, articleId } },
+    });
+    return { liked: false };
+  } else {
+    await prisma.like.create({
+      data: { userId, articleId },
+    });
+    return { liked: true };
+  }
+};


### PR DESCRIPTION
closes #21 

## 작업 내용
기사에 좋아요를 누르는 api 추가했습니다.
사용자가 이미 좋아요 누른 기사이면 좋아요 취소, 아닐 경우 좋아요 추가

## 체크리스트
- [x] 로컬 동작 확인
- [x] ESLint 오류 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 기사 좋아요 토글 기능 추가: 인증된 사용자는 기사에 좋아요를 추가하거나 취소할 수 있습니다.  
  * 좋아요는 단일 엔드포인트로 토글되며, 존재하지 않는 기사에 대한 요청은 404를 반환합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->