### PR TITLE
fix: 조회수 로직 변경

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -107,6 +107,7 @@ model Article {
   sources         ArticleSource[]
   comments        Comment[]
   likes           Like[]
+  views           ArticleView[]
 
   @@map("articles")
 }
@@ -161,6 +162,21 @@ model Like {
   @@map("likes")
 }
 
+
+// ============================================
+// ARTICLE VIEW (조회수 중복 방지)
+// ============================================
+
+model ArticleView {
+  id        Int      @id @default(autoincrement())
+  articleId String   @db.Uuid @map("article_id")
+  viewerKey String   @map("viewer_key") // 로그인: userId / 비로그인: IP주소
+
+  article   Article  @relation(fields: [articleId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@unique([articleId, viewerKey])
+  @@map("article_views")
+}
 
 // ============================================
 // FEEDBACK

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -170,7 +170,8 @@ model Like {
 model ArticleView {
   id        Int      @id @default(autoincrement())
   articleId String   @db.Uuid @map("article_id")
-  viewerKey String   @map("viewer_key") // 로그인: userId / 비로그인: IP주소
+  viewerKey String   @map("viewer_key") // 로그인: user:<userId> / 비로그인: ip:<ip>:<YYYY-MM-DD>
+  createdAt DateTime @default(now()) @db.Timestamptz(6) @map("created_at")
 
   article   Article  @relation(fields: [articleId], references: [id], onDelete: Cascade, onUpdate: NoAction)
 

--- a/src/controllers/article.controller.ts
+++ b/src/controllers/article.controller.ts
@@ -1,5 +1,35 @@
 import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
 import { getArticles, getArticleById } from '../services/article.service';
+import { JwtPayload } from '../middlewares/auth.middleware';
+
+/**
+ * 조회수 중복 방지용 viewerKey 추출
+ * - 로그인 유저: userId
+ * - 비로그인: 클라이언트 IP
+ */
+const extractViewerKey = (req: Request): string => {
+  // 로그인 유저면 userId 우선
+  const authHeader = req.headers.authorization;
+  if (authHeader?.startsWith('Bearer ')) {
+    try {
+      const secret = process.env.JWT_SECRET || 'fallback-secret';
+      const decoded = jwt.verify(authHeader.split(' ')[1], secret) as JwtPayload;
+      return `user:${decoded.userId}`;
+    } catch {
+      // 토큰 유효하지 않으면 IP로 fallback
+    }
+  }
+
+  // 비로그인: IP 추출 (프록시/로드밸런서 헤더 우선)
+  const forwarded = req.headers['x-forwarded-for'];
+  const ip =
+    (typeof forwarded === 'string' ? forwarded.split(',')[0].trim() : undefined) ??
+    req.socket.remoteAddress ??
+    'unknown';
+
+  return `ip:${ip}`;
+};
 
 export const getArticlesController = async (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -23,7 +53,8 @@ export const getArticlesController = async (req: Request, res: Response, next: N
 
 export const getArticleController = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const article = await getArticleById(req.params.id as string);
+    const viewerKey = extractViewerKey(req);
+    const article = await getArticleById(req.params.id as string, viewerKey);
 
     if (!article) {
       res.status(404).json({ success: false, message: '기사를 찾을 수 없습니다.' });

--- a/src/controllers/article.controller.ts
+++ b/src/controllers/article.controller.ts
@@ -1,34 +1,21 @@
 import { Request, Response, NextFunction } from 'express';
-import jwt from 'jsonwebtoken';
 import { getArticles, getArticleById } from '../services/article.service';
-import { JwtPayload } from '../middlewares/auth.middleware';
 
-/**
- * 조회수 중복 방지용 viewerKey 추출
- * - 로그인 유저: userId
- * - 비로그인: 클라이언트 IP
- */
-const extractViewerKey = (req: Request): string => {
-  // 로그인 유저면 userId 우선
-  const authHeader = req.headers.authorization;
-  if (authHeader?.startsWith('Bearer ')) {
-    try {
-      const secret = process.env.JWT_SECRET || 'fallback-secret';
-      const decoded = jwt.verify(authHeader.split(' ')[1], secret) as JwtPayload;
-      return `user:${decoded.userId}`;
-    } catch {
-      // 토큰 유효하지 않으면 IP로 fallback
-    }
+/** 조회수 중복 방지용 viewerKey 생성 (optionalAuthMiddleware 실행 후 호출) */
+const buildViewerKey = (req: Request): string => {
+  if (req.user?.userId) {
+    return `user:${req.user.userId}`;
   }
 
-  // 비로그인: IP 추출 (프록시/로드밸런서 헤더 우선)
   const forwarded = req.headers['x-forwarded-for'];
   const ip =
     (typeof forwarded === 'string' ? forwarded.split(',')[0].trim() : undefined) ??
     req.socket.remoteAddress ??
     'unknown';
 
-  return `ip:${ip}`;
+  // 날짜 포함: 하루 단위로 중복 방지 (DHCP/NAT IP 재할당 대응)
+  const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+  return `ip:${ip}:${today}`;
 };
 
 export const getArticlesController = async (req: Request, res: Response, next: NextFunction) => {
@@ -53,7 +40,7 @@ export const getArticlesController = async (req: Request, res: Response, next: N
 
 export const getArticleController = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const viewerKey = extractViewerKey(req);
+    const viewerKey = buildViewerKey(req);
     const article = await getArticleById(req.params.id as string, viewerKey);
 
     if (!article) {

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -38,6 +38,22 @@ export function authMiddleware(req: Request, res: Response, next: NextFunction):
   }
 }
 
+// 선택적 인증 미들웨어 (토큰 있으면 req.user 세팅, 없어도 통과)
+export function optionalAuthMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const authHeader = req.headers.authorization;
+
+  if (authHeader?.startsWith('Bearer ')) {
+    try {
+      const secret = process.env.JWT_SECRET || 'fallback-secret';
+      const decoded = jwt.verify(authHeader.split(' ')[1], secret) as JwtPayload;
+      req.user = decoded;
+    } catch {
+      // 유효하지 않은 토큰이면 req.user 미설정 후 계속 진행
+    }
+  }
+  next();
+}
+
 // 관리자 전용 API에 authMiddleware 다음에 붙이는 미들웨어
 export function adminMiddleware(req: Request, res: Response, next: NextFunction): void {
   if (req.user?.role !== 'ADMIN') {

--- a/src/routes/articles.route.ts
+++ b/src/routes/articles.route.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { getArticlesController, getArticleController } from '../controllers/article.controller';
 import { getComments, createComment } from '../controllers/comment.controller';
 import { toggleLike } from '../controllers/like.controller';
-import { authMiddleware } from '../middlewares/auth.middleware';
+import { authMiddleware, optionalAuthMiddleware } from '../middlewares/auth.middleware';
 
 const router = Router();
 
@@ -68,7 +68,7 @@ router.get('/', getArticlesController);
  *       404:
  *         description: 컨텐츠 없음
  */
-router.get('/:id', getArticleController);
+router.get('/:id', optionalAuthMiddleware, getArticleController);
 
 /**
  * @swagger

--- a/src/services/article.service.ts
+++ b/src/services/article.service.ts
@@ -72,7 +72,7 @@ export const getArticles = async ({
   };
 };
 
-export const getArticleById = async (id: string) => {
+export const getArticleById = async (id: string, viewerKey?: string) => {
   const article = await prisma.article.findUnique({
     where: { id },
     include: {
@@ -84,6 +84,19 @@ export const getArticleById = async (id: string) => {
 
   if (!article || article.status !== 'PUBLISHED') return null;
 
+  if (viewerKey) {
+    try {
+      // 이미 조회 기록이 있으면 P2002(unique 충돌) → 카운트 생략
+      await prisma.articleView.create({ data: { articleId: id, viewerKey } });
+    } catch (e) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
+        return article;
+      }
+      console.error('[viewCount] articleView 생성 실패:', e);
+    }
+  }
+
+  // 첫 조회이거나 viewerKey가 없는 경우 카운트 증가
   return prisma.article.update({
     where: { id },
     data: { viewCount: { increment: 1 } },


### PR DESCRIPTION
closes #25 

## 작업 내용
같은 공고에 같은 유저의 경우 조회수가 한번만 올라가도록 수정.
비로그인 유저일 경우에도 ip별로 한번만 조회수 올라가도록 수정
article_view 테이블 추가

## 체크리스트
- [x] 로컬 동작 확인
- [x] ESLint 오류 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 기사 조회 추적이 개선되었습니다. 사용자별 또는 IP 기반의 고유한 조회를 구분하여 더 정확한 조회수 데이터를 제공합니다. 각 뷰어의 조회가 개별적으로 기록되어 중복 계산을 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->