### PR TITLE
fix: 댓글더보기페이지네이션

### DIFF
--- a/src/controllers/comment.controller.ts
+++ b/src/controllers/comment.controller.ts
@@ -4,7 +4,7 @@ import * as commentService from '../services/comment.service';
 export const getComments = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const cursor = typeof req.query.cursor === 'string' ? req.query.cursor : undefined;
-    const limit = Math.min(Number(req.query.limit) || 10, 50); // 최대 50개 제한
+    const limit = Math.min(Math.max(Math.floor(Number(req.query.limit) || 10), 1), 50); // 1~50 정수 clamp
 
     const result = await commentService.getComments(req.params.id as string, cursor, limit);
     res.json({ success: true, ...result });

--- a/src/controllers/comment.controller.ts
+++ b/src/controllers/comment.controller.ts
@@ -3,8 +3,11 @@ import * as commentService from '../services/comment.service';
 
 export const getComments = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const comments = await commentService.getComments(req.params.id as string);
-    res.json({ success: true, data: comments });
+    const cursor = typeof req.query.cursor === 'string' ? req.query.cursor : undefined;
+    const limit = Math.min(Number(req.query.limit) || 10, 50); // 최대 50개 제한
+
+    const result = await commentService.getComments(req.params.id as string, cursor, limit);
+    res.json({ success: true, ...result });
   } catch (err) {
     next(err);
   }

--- a/src/routes/articles.route.ts
+++ b/src/routes/articles.route.ts
@@ -137,7 +137,7 @@ router.post('/:id/like', authMiddleware, toggleLike);
  * @swagger
  * /api/articles/{id}/comments:
  *   get:
- *     summary: 특정 기사의 댓글 리스트 조회 🥒
+ *     summary: 특정 기사의 댓글 리스트 조회 (최신순, 커서 페이지네이션) 🥒
  *     tags: [Articles]
  *     parameters:
  *       - in: path
@@ -145,9 +145,36 @@ router.post('/:id/like', authMiddleware, toggleLike);
  *         required: true
  *         schema:
  *           type: string
+ *       - in: query
+ *         name: cursor
+ *         schema:
+ *           type: string
+ *         description: 마지막으로 받은 댓글 ID (없으면 첫 페이지)
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 10
+ *         description: 가져올 댓글 수 (기본 10, 최대 50)
  *     responses:
  *       200:
  *         description: 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 data:
+ *                   type: array
+ *                 nextCursor:
+ *                   type: string
+ *                   nullable: true
+ *                   description: 다음 페이지 커서 (null이면 마지막 페이지)
+ *                 hasMore:
+ *                   type: boolean
+ *                   description: 더 불러올 댓글이 있는지 여부
  *   post:
  *     summary: 댓글 작성 🥒
  *     tags: [Articles]

--- a/src/services/comment.service.ts
+++ b/src/services/comment.service.ts
@@ -5,10 +5,10 @@ export const getComments = async (articleId: string, cursor?: string, limit = 10
     where: {
       articleId,
       deletedAt: null,
-      ...(cursor && { id: { lt: cursor } }),
     },
-    orderBy: { createdAt: 'desc' },
+    orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
     take: limit + 1, // 다음 페이지 존재 여부 확인용으로 1개 더 가져옴
+    ...(cursor && { cursor: { id: cursor }, skip: 1 }), // Prisma 내장 커서 (cursor 항목 자체는 skip)
     select: {
       id: true,
       body: true,

--- a/src/services/comment.service.ts
+++ b/src/services/comment.service.ts
@@ -1,12 +1,14 @@
 import { prisma } from '../lib/prisma';
 
-export const getComments = async (articleId: string) => {
-  return prisma.comment.findMany({
+export const getComments = async (articleId: string, cursor?: string, limit = 10) => {
+  const comments = await prisma.comment.findMany({
     where: {
       articleId,
       deletedAt: null,
+      ...(cursor && { id: { lt: cursor } }),
     },
-    orderBy: { createdAt: 'asc' },
+    orderBy: { createdAt: 'desc' },
+    take: limit + 1, // 다음 페이지 존재 여부 확인용으로 1개 더 가져옴
     select: {
       id: true,
       body: true,
@@ -17,6 +19,12 @@ export const getComments = async (articleId: string) => {
       },
     },
   });
+
+  const hasMore = comments.length > limit;
+  const data = hasMore ? comments.slice(0, limit) : comments;
+  const nextCursor = hasMore ? data[data.length - 1].id : null;
+
+  return { data, nextCursor, hasMore };
 };
 
 export const createComment = async (articleId: string, userId: string, body: string) => {


### PR DESCRIPTION
closes #36 

## 작업 내용
댓글 10개이상 늘어나면 더보기 버튼추가, 버튼 누를때마다 10개씩 조회
댓글은 최신순으로 정렬

첫 로딩:    GET /api/articles/:id/comments
더보기 클릭: GET /api/articles/:id/comments?cursor=nextCursor값

## 체크리스트
- [x] 로컬 동작 확인
- [x] ESLint 오류 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 댓글 조회에 커서 기반 페이지네이션 기능 추가됨. limit 파라미터(기본값 10, 최대 50)로 한 번에 가져올 댓글 수 조정 가능. nextCursor와 hasMore 필드를 통해 추가 페이지 여부 확인 가능.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->