### PR TITLE
fix: 댓글,좋아요,ai호출 제한 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 *.log
 .DS_Store
 test-fetch.ts
+test-prompt.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.21.0",
+        "express-rate-limit": "^8.5.1",
         "google-auth-library": "^10.6.2",
         "jsonwebtoken": "^9.0.2",
         "rss-parser": "^3.13.0",
@@ -2615,6 +2616,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -2654,6 +2656,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -3304,6 +3324,15 @@
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.21.0",
+    "express-rate-limit": "^8.5.1",
     "google-auth-library": "^10.6.2",
     "jsonwebtoken": "^9.0.2",
     "rss-parser": "^3.13.0",

--- a/src/middlewares/rateLimit.middleware.ts
+++ b/src/middlewares/rateLimit.middleware.ts
@@ -1,0 +1,40 @@
+import rateLimit from 'express-rate-limit';
+
+/** 일반 API 전체 — 1분에 100회 */
+export const generalLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { success: false, message: '요청이 너무 많습니다. 잠시 후 다시 시도해주세요.' },
+});
+
+/** 댓글 작성 — 1분에 10회 */
+export const commentLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: {
+    success: false,
+    message: '댓글을 너무 빠르게 작성하고 있어요. 잠시 후 다시 시도해주세요.',
+  },
+});
+
+/** 좋아요 — 1분에 30회 */
+export const likeLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { success: false, message: '요청이 너무 많습니다. 잠시 후 다시 시도해주세요.' },
+});
+
+/** 어드민 AI 생성 — 1분에 5회 (Gemini 비용 보호) */
+export const adminAiLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { success: false, message: 'AI 생성 요청이 너무 많습니다. 잠시 후 다시 시도해주세요.' },
+});

--- a/src/routes/admin.route.ts
+++ b/src/routes/admin.route.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { authMiddleware, adminMiddleware } from '../middlewares/auth.middleware';
+import { adminAiLimiter } from '../middlewares/rateLimit.middleware';
 import {
   searchNews,
   generateContent,
@@ -113,7 +114,7 @@ router.post('/pipeline/search', searchNews);
  *       403:
  *         description: 관리자 권한 없음
  */
-router.post('/pipeline/generate', generateContent);
+router.post('/pipeline/generate', adminAiLimiter, generateContent);
 
 /**
  * @swagger

--- a/src/routes/articles.route.ts
+++ b/src/routes/articles.route.ts
@@ -7,6 +7,7 @@ import {
 import { getComments, createComment } from '../controllers/comment.controller';
 import { toggleLike } from '../controllers/like.controller';
 import { authMiddleware, optionalAuthMiddleware } from '../middlewares/auth.middleware';
+import { commentLimiter, likeLimiter } from '../middlewares/rateLimit.middleware';
 
 const router = Router();
 
@@ -131,7 +132,7 @@ router.get('/:id', optionalAuthMiddleware, getArticleController);
  *       401:
  *         description: 인증 필요
  */
-router.post('/:id/like', authMiddleware, toggleLike);
+router.post('/:id/like', authMiddleware, likeLimiter, toggleLike);
 
 /**
  * @swagger
@@ -202,6 +203,6 @@ router.post('/:id/like', authMiddleware, toggleLike);
  *         description: 인증 필요
  */
 router.get('/:id/comments', getComments);
-router.post('/:id/comments', authMiddleware, createComment);
+router.post('/:id/comments', authMiddleware, commentLimiter, createComment);
 
 export default router;


### PR DESCRIPTION
closes #없음

## 작업 내용
동일 ip에 일정시간 너무 많은 요청이 들어오는것을 막는 미들웨어를 추가했습니다.
댓글-1분30회
좋아요-1분30회
ai생성-1분5회
회수는 추후 조정

express-rate-limit 라이브러리 추가함
 -> npm install express-rate-limit

## 체크리스트
- [ ] 로컬 동작 확인
- [ ] ESLint 오류 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * API 요청 속도 제한 기능 추가: 일반 요청(분당 100), 댓글 작성(분당 10), 좋아요(분당 30), 관리자 AI 생성(분당 5) 각각의 제한값 적용
  * 과도한 API 사용 방지로 서비스 안정성 향상

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Corea-Hoy/Corea-Hoy-BE/pull/38)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->