### PR TITLE
fix: 상세조회에 isliked 항목추가

### DIFF
--- a/src/controllers/article.controller.ts
+++ b/src/controllers/article.controller.ts
@@ -39,7 +39,8 @@ export const getArticlesController = async (req: Request, res: Response, next: N
 export const getArticleController = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const viewerKey = buildViewerKey(req);
-    const article = await getArticleById(req.params.id as string, viewerKey);
+    const userId = req.user?.userId;
+    const article = await getArticleById(req.params.id as string, viewerKey, userId);
 
     if (!article) {
       res.status(404).json({ success: false, message: '기사를 찾을 수 없습니다.' });

--- a/src/services/article.service.ts
+++ b/src/services/article.service.ts
@@ -72,7 +72,7 @@ export const getArticles = async ({
   };
 };
 
-export const getArticleById = async (id: string, viewerKey?: string) => {
+export const getArticleById = async (id: string, viewerKey?: string, userId?: string) => {
   const article = await prisma.article.findUnique({
     where: { id },
     include: {
@@ -89,21 +89,35 @@ export const getArticleById = async (id: string, viewerKey?: string) => {
       await prisma.articleView.create({ data: { articleId: id, viewerKey } });
     } catch (e) {
       if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
-        return article;
+        const isLiked = userId
+          ? !!(await prisma.like.findUnique({
+              where: { userId_articleId: { userId, articleId: id } },
+            }))
+          : false;
+        return { ...article, isLiked };
       }
       console.error('[viewCount] articleView 생성 실패:', e);
     }
   }
 
-  return prisma.article.update({
-    where: { id },
-    data: { viewCount: { increment: 1 } },
-    include: {
-      category: { select: { id: true, name: true, slug: true } },
-      sources: true,
-      _count: { select: { likes: true, comments: true } },
-    },
-  });
+  const [updated, isLiked] = await Promise.all([
+    prisma.article.update({
+      where: { id },
+      data: { viewCount: { increment: 1 } },
+      include: {
+        category: { select: { id: true, name: true, slug: true } },
+        sources: true,
+        _count: { select: { likes: true, comments: true } },
+      },
+    }),
+    userId
+      ? prisma.like
+          .findUnique({ where: { userId_articleId: { userId, articleId: id } } })
+          .then(Boolean)
+      : Promise.resolve(false),
+  ]);
+
+  return { ...updated, isLiked };
 };
 
 export const getArticleSuggestions = async (q: string) => {


### PR DESCRIPTION
closes #없어요

## 작업 내용
로그아웃을 해도 좋아요 상태가 저장되도록 기사 상세조회에 islike 전달하도록 수정

## 체크리스트
- [ ] 로컬 동작 확인
- [ ] ESLint 오류 없음
