### PR TITLE
fix: 좋아요 응답구조변경

### DIFF
--- a/src/services/like.service.ts
+++ b/src/services/like.service.ts
@@ -6,14 +6,18 @@ export const toggleLike = async (articleId: string, userId: string) => {
   if (!article) return null;
 
   try {
+    // 좋아요 추가 + 총 개수 동시 조회
     await prisma.like.create({ data: { userId, articleId } });
-    return { liked: true };
+    const likeCount = await prisma.like.count({ where: { articleId } });
+    return { liked: true, likeCount };
   } catch (e) {
     if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
-      await prisma.like.delete({
-        where: { userId_articleId: { userId, articleId } },
-      });
-      return { liked: false };
+      // 좋아요 삭제 + 총 개수 동시 조회
+      const [, likeCount] = await Promise.all([
+        prisma.like.delete({ where: { userId_articleId: { userId, articleId } } }),
+        prisma.like.count({ where: { articleId } }).then((count) => count - 1), // 삭제 후 개수
+      ]);
+      return { liked: false, likeCount };
     }
     throw e;
   }

--- a/src/services/like.service.ts
+++ b/src/services/like.service.ts
@@ -12,11 +12,9 @@ export const toggleLike = async (articleId: string, userId: string) => {
     return { liked: true, likeCount };
   } catch (e) {
     if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
-      // 좋아요 삭제 + 총 개수 동시 조회
-      const [, likeCount] = await Promise.all([
-        prisma.like.delete({ where: { userId_articleId: { userId, articleId } } }),
-        prisma.like.count({ where: { articleId } }).then((count) => count - 1), // 삭제 후 개수
-      ]);
+      // 삭제 완료 후 카운트 조회 (순서 보장)
+      await prisma.like.delete({ where: { userId_articleId: { userId, articleId } } });
+      const likeCount = await prisma.like.count({ where: { articleId } });
       return { liked: false, likeCount };
     }
     throw e;


### PR DESCRIPTION
closes #이슈번호

## 작업 내용
좋아요 api에 true, false값만이 아니라 총 count값도 함께 응답으로 보내주도록 수정
// 좋아요 누를 때
{ "success": true, "data": { "liked": true, "likeCount": 43 } }

// 좋아요 취소할 때
{ "success": true, "data": { "liked": false, "likeCount": 42 } }
## 체크리스트
- [ ] 로컬 동작 확인
- [ ] ESLint 오류 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 좋아요 토글 동작이 확장되어, 사용자의 좋아요 여부(liked)와 게시물의 현재 총 좋아요 수(likeCount)를 함께 실시간으로 제공합니다. 게시물이 없을 경우 기존처럼 null을 반환합니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Corea-Hoy/Corea-Hoy-BE/pull/42)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->