### PR TITLE
fix: 로직 트랜잭션으로 묶음

### DIFF
--- a/src/services/article.service.ts
+++ b/src/services/article.service.ts
@@ -99,9 +99,31 @@ export const getArticleById = async (id: string, viewerKey?: string, userId?: st
 
   if (viewerKey) {
     try {
-      await prisma.articleView.create({ data: { articleId: id, viewerKey } });
+      // ArticleView 생성 + viewCount 증가를 트랜잭션으로 묶어 데이터 일관성 보장
+      const [updated, isLiked] = await Promise.all([
+        prisma.$transaction([
+          prisma.articleView.create({ data: { articleId: id, viewerKey } }),
+          prisma.article.update({
+            where: { id },
+            data: { viewCount: { increment: 1 } },
+            include: {
+              category: { select: { id: true, name: true, slug: true } },
+              sources: true,
+              _count: { select: { likes: true, comments: true } },
+            },
+          }),
+        ]),
+        userId
+          ? prisma.like
+              .findUnique({ where: { userId_articleId: { userId, articleId: id } } })
+              .then(Boolean)
+          : Promise.resolve(false),
+      ]);
+
+      return { ...(updated[1] as typeof article), isLiked };
     } catch (e) {
       if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
+        // 중복 조회 — viewCount 증가 없이 기사만 반환
         const isLiked = userId
           ? !!(await prisma.like.findUnique({
               where: { userId_articleId: { userId, articleId: id } },
@@ -109,28 +131,15 @@ export const getArticleById = async (id: string, viewerKey?: string, userId?: st
           : false;
         return { ...article, isLiked };
       }
-      console.error('[viewCount] articleView 생성 실패:', e);
+      console.error('[viewCount] 트랜잭션 실패:', e);
     }
   }
 
-  const [updated, isLiked] = await Promise.all([
-    prisma.article.update({
-      where: { id },
-      data: { viewCount: { increment: 1 } },
-      include: {
-        category: { select: { id: true, name: true, slug: true } },
-        sources: true,
-        _count: { select: { likes: true, comments: true } },
-      },
-    }),
-    userId
-      ? prisma.like
-          .findUnique({ where: { userId_articleId: { userId, articleId: id } } })
-          .then(Boolean)
-      : Promise.resolve(false),
-  ]);
-
-  return { ...updated, isLiked };
+  // viewerKey 없는 경우 (중복 방지 없이 기사만 반환)
+  const isLiked = userId
+    ? !!(await prisma.like.findUnique({ where: { userId_articleId: { userId, articleId: id } } }))
+    : false;
+  return { ...article, isLiked };
 };
 
 export const getArticleSuggestions = async (q: string) => {


### PR DESCRIPTION
closes #이슈번호

## 작업 내용
ArticleView.create + viewCount +1 → 트랜잭션으로 묶음 (둘 다 성공하거나 둘 다 롤백)
P2002(중복 조회) → 트랜잭션 실패로 잡혀서 조회수 증가 없이 기사만 반환 (기존과 동일)

## 체크리스트
- [ ] 로컬 동작 확인
- [ ] ESLint 오류 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 중복된 조회 시도에 대한 처리 개선으로 조회수 계산이 더욱 안정적입니다.
  
* **성능 개선**
  * 아티클 조회 시 데이터베이스 작업 최적화로 응답 속도가 향상되었습니다.
  * 좋아요 상태 확인이 함께 개선되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Corea-Hoy/Corea-Hoy-BE/pull/44)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->