### PR TITLE
feat: 관리자 임시저장 및 이어서 쓰기 지원 API 구현

### DIFF
--- a/src/controllers/admin.controller.ts
+++ b/src/controllers/admin.controller.ts
@@ -90,6 +90,21 @@ export const getAdminArticles = async (req: Request, res: Response, next: NextFu
   }
 };
 
+export const getAdminArticleById = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const article = await adminService.getAdminArticleById(req.params.id as string);
+
+    if (!article) {
+      res.status(404).json({ success: false, message: '기사를 찾을 수 없습니다.' });
+      return;
+    }
+
+    res.json({ success: true, data: article });
+  } catch (err) {
+    next(err);
+  }
+};
+
 export const createDraftArticle = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const {

--- a/src/routes/admin.route.ts
+++ b/src/routes/admin.route.ts
@@ -5,6 +5,7 @@ import {
   searchNews,
   generateContent,
   getAdminArticles,
+  getAdminArticleById,
   createDraftArticle,
   updateArticle,
   publishArticle,
@@ -144,7 +145,7 @@ router.post('/pipeline/generate', adminAiLimiter, generateContent);
  *           default: 20
  *     responses:
  *       200:
- *         description: "{ articles, pagination: { total, page, limit, totalPages } }"
+ *         description: "{ articles, counts: { total, DRAFT, PUBLISHED, ARCHIVED }, pagination: { total, page, limit, totalPages } }"
  *   post:
  *     summary: "③ 기사 DRAFT 저장 🥒"
  *     description: |
@@ -219,11 +220,30 @@ router.post('/pipeline/generate', adminAiLimiter, generateContent);
  *         description: 필수 필드 누락 또는 유효하지 않은 값
  */
 router.get('/articles', getAdminArticles);
+router.get('/articles/:id', getAdminArticleById);
 router.post('/articles', createDraftArticle);
 
 /**
  * @swagger
  * /api/admin/articles/{id}:
+ *   get:
+ *     summary: "기사 상세 조회 (이어서 쓰기용) 🥒"
+ *     description: 특정 기사의 모든 상세 데이터를 조회합니다. '이어서 작업하기' 클릭 시 호출합니다.
+ *     tags: [Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: 기사 UUID
+ *     responses:
+ *       200:
+ *         description: 기사 상세 정보 반환
+ *       404:
+ *         description: 기사를 찾을 수 없음
  *   put:
  *     summary: "기사 내용 수동 수정 🥒"
  *     description: 저장된 기사 내용을 수정합니다. 수정할 필드만 포함해서 보내면 됩니다.

--- a/src/services/admin.service.ts
+++ b/src/services/admin.service.ts
@@ -475,7 +475,7 @@ export const getAdminArticles = async (status?: ArticleStatus, page = 1, limit =
   const where: Prisma.ArticleWhereInput = status ? { status } : {};
   const skip = (page - 1) * limit;
 
-  const [articles, total] = await Promise.all([
+  const [articles, total, counts] = await Promise.all([
     prisma.article.findMany({
       where,
       orderBy: { createdAt: 'desc' },
@@ -498,9 +498,35 @@ export const getAdminArticles = async (status?: ArticleStatus, page = 1, limit =
       },
     }),
     prisma.article.count({ where }),
+    prisma.article.groupBy({
+      by: ['status'],
+      _count: { status: true },
+    }),
   ]);
 
-  return { articles, pagination: { total, page, limit, totalPages: Math.ceil(total / limit) } };
+  const countMap = {
+    total: counts.reduce((acc, curr) => acc + curr._count.status, 0),
+    DRAFT: counts.find((c) => c.status === 'DRAFT')?._count.status || 0,
+    PUBLISHED: counts.find((c) => c.status === 'PUBLISHED')?._count.status || 0,
+    ARCHIVED: counts.find((c) => c.status === 'ARCHIVED')?._count.status || 0,
+  };
+
+  return {
+    articles,
+    counts: countMap,
+    pagination: { total, page, limit, totalPages: Math.ceil(total / limit) },
+  };
+};
+
+export const getAdminArticleById = async (id: string) => {
+  return prisma.article.findUnique({
+    where: { id },
+    include: {
+      category: { select: { id: true, name: true, slug: true } },
+      sources: true,
+      _count: { select: { likes: true, comments: true } },
+    },
+  });
 };
 
 export const createDraftArticle = async (data: {


### PR DESCRIPTION
closes #47 

## 작업 내용
- 관리자 콘솔 '이어서 쓰기' 기능을 위한 단일 기사 상세 조회 API 추가
- 기사 목록 조회 시 상단 탭용 상태별(DRAFT, PUBLISHED 등) 개수 반환 기능 추가

## 체크리스트
- [x] 로컬 동작 확인
- [x] ESLint 오류 없음
