### PR TITLE
fix: 제목기준 중복 기사 필터

### DIFF
--- a/src/services/admin.service.ts
+++ b/src/services/admin.service.ts
@@ -252,18 +252,25 @@ export const searchNews = async () => {
   const youtubeArticles = await collectYouTube();
   articles.push(...youtubeArticles);
 
-  // DB 중복 제거
+  // DB 중복 제거 (URL + 최근 30일 제목)
+  const normalizeTitle = (title: string) => title.replace(/[^\p{L}\p{N}]/gu, '').toLowerCase();
+
   const urls = articles.map((a) => a.url).filter(Boolean);
-  const existing = await prisma.articleSource.findMany({
-    where: { url: { in: urls } },
-    select: { url: true },
-  });
+  const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  const [existing, recentArticles] = await Promise.all([
+    prisma.articleSource.findMany({
+      where: { url: { in: urls } },
+      select: { url: true },
+    }),
+    prisma.article.findMany({
+      where: { createdAt: { gte: since } },
+      select: { titleKo: true },
+    }),
+  ]);
   const existingUrls = new Set(existing.map((s) => s.url));
 
-  const normalizeTitle = (title: string) => title.replace(/[\s\W_]+/g, '').toLowerCase();
-
   const seenUrls = new Set<string>();
-  const seenTitles = new Set<string>();
+  const seenTitles = new Set<string>(recentArticles.map((a) => normalizeTitle(a.titleKo)));
   const deduped = articles
     .filter((a) => {
       const normTitle = normalizeTitle(a.title);

--- a/src/services/admin.service.ts
+++ b/src/services/admin.service.ts
@@ -260,11 +260,16 @@ export const searchNews = async () => {
   });
   const existingUrls = new Set(existing.map((s) => s.url));
 
+  const normalizeTitle = (title: string) => title.replace(/[\s\W_]+/g, '').toLowerCase();
+
   const seenUrls = new Set<string>();
+  const seenTitles = new Set<string>();
   const deduped = articles
     .filter((a) => {
-      if (existingUrls.has(a.url) || seenUrls.has(a.url)) return false;
+      const normTitle = normalizeTitle(a.title);
+      if (existingUrls.has(a.url) || seenUrls.has(a.url) || seenTitles.has(normTitle)) return false;
       seenUrls.add(a.url);
+      seenTitles.add(normTitle);
       return true;
     })
     .filter((a) => a.thumbnailUrl !== null)


### PR DESCRIPTION
closes #이슈번호

## 작업 내용
기존에는 동일한 링크링 경우에만 중복으로 처리했는데 이제 다른 링크여도 제목이 같은 내용이면 중복으로 처리하도록 변경

## 체크리스트
- [ ] 로컬 동작 확인
- [ ] ESLint 오류 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 뉴스 검색에서 중복된 기사 제거 알고리즘을 개선했습니다. URL뿐만 아니라 정규화된 기사 제목도 함께 비교하여 더욱 정확한 중복 제거를 수행합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Corea-Hoy/Corea-Hoy-BE/pull/49)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->