### PR TITLE
fix: 기사랜덤뽑기수정

### DIFF
--- a/src/services/admin.service.ts
+++ b/src/services/admin.service.ts
@@ -291,39 +291,26 @@ export const searchNews = async () => {
     }
   }
 
-  const sourceMap = new Map<string, NewsArticle[]>();
+  // 카테고리별로 그룹화 후 셔플
+  const categoryMap = new Map<string, NewsArticle[]>();
   for (const article of deduped) {
-    if (!sourceMap.has(article.source)) sourceMap.set(article.source, []);
-    sourceMap.get(article.source)!.push(article);
+    if (!categoryMap.has(article.category)) categoryMap.set(article.category, []);
+    categoryMap.get(article.category)!.push(article);
   }
-  for (const group of sourceMap.values()) {
+  for (const group of categoryMap.values()) {
     for (let i = group.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
       [group[i], group[j]] = [group[j], group[i]];
     }
   }
 
-  const sources = [...sourceMap.values()];
-  const counts = new Array(sources.length).fill(0);
-  const indices = new Array(sources.length).fill(0);
+  // 카테고리별 최대 4개, 총 최대 24개
   const selected: NewsArticle[] = [];
-
-  while (selected.length < 15) {
-    let added = false;
-    for (let i = 0; i < sources.length; i++) {
-      if (selected.length >= 15) break;
-      if (counts[i] >= 3) continue;
-      if (indices[i] < sources[i].length) {
-        selected.push(sources[i][indices[i]]);
-        indices[i]++;
-        counts[i]++;
-        added = true;
-      }
-    }
-    if (!added) break;
+  for (const group of categoryMap.values()) {
+    selected.push(...group.slice(0, 4));
   }
 
-  return selected;
+  return selected.slice(0, 24);
 };
 
 export const generateContent = async (


### PR DESCRIPTION
closes #이슈번호

## 작업 내용
기존
1라운드: 연합뉴스1, 매일경제1, 스타뉴스1, SBS1, HYBE1 ...
2라운드: 연합뉴스2, 매일경제2, 스타뉴스2, SBS2, HYBE2 ...
3라운드: 연합뉴스3, 매일경제3 ...  (소스당 최대 3개)
수정
카테고리별로 최대4개, 총 24개

## 체크리스트
- [ ] 로컬 동작 확인
- [ ] ESLint 오류 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선 사항

* 뉴스 검색 결과를 카테고리별로 재정렬하여 더 균형잡힌 결과 제공
* 카테고리별 최대 4개 기사 표시로 다양한 관점의 뉴스 노출
* 최대 검색 결과 수 확대 (15개 → 24개)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Corea-Hoy/Corea-Hoy-BE/pull/50)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->